### PR TITLE
Release v0.3.3: anchored docs clarified, stricter tests, MSRV-safe dev-dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2025-09-09
+
+### Changed
+- Documentation and examples now pass raw anchors to `anchored_canonicalize`; clarified that the API soft-canonicalizes the anchor internally. No API changes.
+
+### Added
+- New Windows tests asserting exact, literal extended-length paths (e.g., `\\?\C:\Users\…`) for non-existing anchors and inputs.
+- Test covering anchors that include `..` segments, confirming internal soft-canonicalization normalizes the base and yields equal results for equivalent inputs.
+
+### Improved
+- Test style hardened across the suite:
+  - Prefer full `assert_eq!` comparisons over `starts_with`/`ends_with` hints.
+  - Use raw strings for Windows inputs and readable, single-join or full-literal expected paths.
+- Added “Testing Rules for Agents (must follow)” to `AGENTS.md` to codify exact-equality expectations, Windows raw-string usage, anchored semantics, symlink policy, and environment assumptions.
+- Clarified ADS/CVE coverage in security tests; no behavior changes.
+
+### Notes
+- Behavior is unchanged; this release focuses on clearer docs/examples and stricter, more readable tests.
+
 ## [0.3.2] - 2025-01-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ bash ci-local.sh
 
 This runs all checks (format, clippy, tests, docs, security audit, MSRV) and ensures std compatibility. If it passes, your code is ready.
 
-**Test Coverage**: The project has 299 tests total:
+**Test Coverage**: The project has 301 tests total:
 
 - 78 unit tests (in `src/tests/`)
 - 6 complex attack tests (blackbox security)  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soft-canonicalize"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 description = "Path canonicalization that works with non-existing paths."
@@ -17,7 +17,9 @@ rust-version = "1.70.0"
 # Zero dependencies - pure std library implementation
 
 [dev-dependencies]
-tempfile = "3.8"
+# MSRV guard: tempfile >=3.22 pulls windows-sys 0.61+ requiring rustc >=1.71.
+# 3.21 is the last known version that builds cleanly on Rust 1.70.0.
+tempfile = "=3.21"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 **🚀 Works with non-existing paths** - Plan file locations before creating them  
 **⚡ Fast** - Mixed workload median performance (5-run protocol): Windows ~1.8x (10,217 paths/s), Linux ~3.8x (352,751 paths/s) faster than Python's pathlib  
 **✅ Compatible** - 100% behavioral match with `std::fs::canonicalize` for existing paths  
-**🔒 Robust** - 299 comprehensive tests including symlink cycle protection, malicious stream validation, and edge case handling  
+**🔒 Robust** - 301 comprehensive tests including symlink cycle protection, malicious stream validation, and edge case handling  
 **🛡️ Robust path handling** - Proper `..` and symlink resolution with cycle detection  
 **🌍 Cross-platform** - Windows, macOS, Linux with comprehensive UNC/symlink handling  
 **🔧 Zero dependencies** - Only uses std library
@@ -85,7 +85,7 @@ Key features of `anchored_canonicalize`:
 
 ### Test Coverage
 
-**299 comprehensive tests** including:
+**301 comprehensive tests** including:
 
 - **11 std::fs::canonicalize compatibility tests** ensuring 100% behavioral compatibility
 - **80+ robustness tests** covering consistent canonicalization behavior and edge cases  
@@ -141,13 +141,13 @@ Each crate serves different use cases. Choose based on your primary need:
 
 ### Feature Comparison
 
-| Feature                       | `soft_canonicalize` | `std::fs::canonicalize` | `dunce::canonicalize` | `normpath::normalize` | `path_absolutize` | `jailed-path`       |
-| ----------------------------- | ------------------- | ----------------------- | --------------------- | --------------------- | ----------------- | ------------------- |
-| Works with non-existing paths | ✅                   | ❌                       | ❌                     | ✅                     | ✅                 | ✅ (via this crate)  |
-| Resolves symlinks             | ✅                   | ✅                       | ✅                     | ❌                     | ❌                 | ✅ (via this crate)  |
-| Windows UNC path support      | ✅                   | ✅                       | ✅                     | ✅                     | ❌                 | ✅ (via this crate)  |
-| Zero dependencies             | ✅                   | ✅                       | ✅                     | ❌                     | ❌                 | ❌ (uses this crate) |
-| Anchored canonicalization     | ✅ (`anchored_canonicalize`) | ❌ | ❌                     | ❌                     | ❌                 | ❌                   |
+| Feature                       | `soft_canonicalize`         | `std::fs::canonicalize` | `dunce::canonicalize` | `normpath::normalize` | `path_absolutize` | `jailed-path`       |
+| ----------------------------- | --------------------------- | ----------------------- | --------------------- | --------------------- | ----------------- | ------------------- |
+| Works with non-existing paths | ✅                           | ❌                       | ❌                     | ✅                     | ✅                 | ✅ (via this crate)  |
+| Resolves symlinks             | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ✅ (via this crate)  |
+| Windows UNC path support      | ✅                           | ✅                       | ✅                     | ✅                     | ❌                 | ✅ (via this crate)  |
+| Zero dependencies             | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ❌ (uses this crate) |
+| Anchored canonicalization     | ✅ (`anchored_canonicalize`) | ❌                       | ❌                     | ❌                     | ❌                 | ❌                   |
 
 ## Known Limitations
 

--- a/examples/anchored_canonicalize.rs
+++ b/examples/anchored_canonicalize.rs
@@ -4,9 +4,9 @@ use soft_canonicalize::anchored_canonicalize;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Anchored Canonicalization Demo ===\n");
 
-    // Set up an anchor directory
+    // Set up an anchor directory (no need to pre-canonicalize; the API handles it)
     let anchor = std::env::temp_dir().join("workspace_root");
-    println!("Anchor directory: {anchor:?}\n");
+    println!("Anchor directory (raw): {anchor:?} — will be soft-canonicalized internally\n");
 
     // Demo 1: Normal paths are resolved relative to the anchor
     println!("--- NORMAL PATHS ---");

--- a/examples/security_demo.rs
+++ b/examples/security_demo.rs
@@ -25,7 +25,7 @@ fn validate_user_path_manual(user_input: &str, jail_dir: &Path) -> Result<PathBu
 fn validate_user_path_anchored(user_input: &str, jail_dir: &Path) -> Result<PathBuf, String> {
     println!("  [Anchored] Validating user input: {user_input:?}");
 
-    // Use anchored_canonicalize for automatic path jailing
+    // Use anchored_canonicalize for automatic path jailing (no need to pre-canonicalize jail_dir)
     match anchored_canonicalize(jail_dir, user_input) {
         Ok(safe_path) => {
             println!("  [Anchored] Resolved to: {safe_path:?}");
@@ -44,9 +44,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Set up a jail directory
     let jail = std::env::temp_dir().join("user_files");
+    // For manual validation we use a canonicalized jail; anchored variant can take raw path too
     let canonical_jail = soft_canonicalize(&jail)?;
 
-    println!("Jail directory: {canonical_jail:?}\n");
+    println!("Jail directory (canonical for manual demo): {canonical_jail:?}\n");
 
     // Test cases: safe paths
     println!("--- SAFE PATHS ---");
@@ -65,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(_) => println!(),
             Err(e) => println!("  Error: {e}\n"),
         }
-        match validate_user_path_anchored(path, &canonical_jail) {
+        match validate_user_path_anchored(path, &jail) {
             Ok(_) => println!(),
             Err(e) => println!("  Error: {e}\n"),
         }
@@ -90,7 +91,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(_) => println!(),
             Err(e) => println!("  [Manual] Expected: {e}\n"),
         }
-        match validate_user_path_anchored(path, &canonical_jail) {
+        match validate_user_path_anchored(path, &jail) {
             Ok(_) => println!(),
             Err(e) => println!("  [Anchored] Expected: {e}\n"),
         }
@@ -120,7 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(_) => println!(),
             Err(e) => println!("  [Manual] Expected: {e}\n"),
         }
-        match validate_user_path_anchored(path, &canonical_jail) {
+        match validate_user_path_anchored(path, &jail) {
             Ok(_) => println!(),
             Err(e) => println!("  [Anchored] Expected: {e}\n"),
         }
@@ -143,7 +144,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             Ok(_) => println!(),
             Err(e) => println!("  [Manual] Result: {e}\n"),
         }
-        match validate_user_path_anchored(path, &canonical_jail) {
+        match validate_user_path_anchored(path, &jail) {
             Ok(_) => println!(),
             Err(e) => println!("  [Anchored] Result: {e}\n"),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,12 +62,13 @@
 //! // Set up an anchor directory
 //! let root = std::env::temp_dir().join("workspace_root");
 //! fs::create_dir_all(&root)?;
-//! let anchor = soft_canonicalize(&root)?;
+//! // No need to pre-canonicalize: anchored_canonicalize soft-canonicalizes the anchor internally
+//! let anchor = &root;
 //!
 //! // Canonicalize user input relative to anchor
 //! let user_input = "../../../etc/passwd";
 //! # #[cfg(feature = "anchored")]
-//! let resolved_path = anchored_canonicalize(&anchor, user_input)?;
+//! let resolved_path = anchored_canonicalize(anchor, user_input)?;
 //! # #[cfg(not(feature = "anchored"))]
 //! # { let _ = user_input; }
 //! # #[cfg(feature = "anchored")]
@@ -104,7 +105,7 @@
 //!
 //! ## Testing
 //!
-//! 299 tests including:
+//! 301 tests including:
 //! - std::fs::canonicalize compatibility tests (existing paths)
 //! - Path traversal and robustness tests
 //! - Python pathlib-inspired behavior checks

--- a/src/tests/anchored_canonicalize.rs
+++ b/src/tests/anchored_canonicalize.rs
@@ -141,10 +141,10 @@ fn anchored_basic_clamp_windows() -> std::io::Result<()> {
     let out1 = anchored_canonicalize(&abs_anchor, r"/etc/passwd")?;
     let out2 = anchored_canonicalize(&abs_anchor, r"..\\..\\..\\etc\\passwd")?;
 
-    assert!(out1.starts_with(&abs_anchor));
-    assert!(out2.starts_with(&abs_anchor));
-    assert!(out1.ends_with("etc\\passwd") || out1.ends_with("etc/passwd"));
-    assert!(out2.ends_with("etc\\passwd") || out2.ends_with("etc/passwd"));
+    let expected =
+        std::path::PathBuf::from(format!(r"{}\etc\passwd", abs_anchor.to_string_lossy()));
+    assert_eq!(out1, expected);
+    assert_eq!(out2, expected);
     Ok(())
 }
 

--- a/src/tests/anchored_security/boundary.rs
+++ b/src/tests/anchored_security/boundary.rs
@@ -26,8 +26,7 @@ fn absolute_and_relative_inputs_under_anchor() -> std::io::Result<()> {
     for (inp, expected_suffix) in cases {
         let out = anchored_canonicalize(&base, inp)?;
         assert!(out.is_absolute());
-        assert!(out.starts_with(&base));
-        assert!(out.ends_with(expected_suffix));
+        assert_eq!(out, expected_suffix);
     }
     Ok(())
 }

--- a/src/tests/anchored_security/dotdot.rs
+++ b/src/tests/anchored_security/dotdot.rs
@@ -51,10 +51,8 @@ fn non_existing_anchor_clamp_windows() -> std::io::Result<()> {
     let base = soft_canonicalize(anchor_missing)?;
 
     let out = anchored_canonicalize(&base, r"..\..\..\etc\passwd")?;
-    // Should be extended-length absolute and clamped to the non-existing anchor base
-    let s = out.to_string_lossy();
-    assert!(s.starts_with(r"\\?\"));
-    assert!(out.starts_with(&base));
-    assert!(out.ends_with("etc\\passwd") || out.ends_with("etc/passwd"));
+    // Should be equal to computed base + suffix (extended-length ensured by base)
+    let expected = std::path::PathBuf::from(format!(r"{}\etc\passwd", base.to_string_lossy()));
+    assert_eq!(out, expected);
     Ok(())
 }


### PR DESCRIPTION
# 🚀 Release v0.3.3: anchored docs clarified, stricter tests, MSRV-safe dev-dep

## 📋 Summary
- ✨ Clarifies anchored behavior: anchor is soft-canonicalized internally; examples no longer pre-canonicalize anchors
- 🔧 Hardens tests to assert full path equality and improves readability on Windows
- 📖 Adds explicit agent testing rules to keep future contributions consistent
- ⚙️ Keeps MSRV at 1.70.0 by pinning the dev-dependency to tempfile 3.21
- ✅ No API or behavioral changes

## 🔄 What changed
- **📚 Documentation and examples**: updated anchored usage to pass raw anchors and documented internal soft-canonicalization
- **🧪 Tests**:
  - Converted path assertions to exact equality instead of prefix/suffix hints
  - Added Windows tests for literal extended-length paths and anchors with dot-dot normalization
  - Simplified expected paths using readable literals
- **📝 Process and guidance**: added Testing Rules for Agents to AGENTS.md
- **🏷️ Versioning**: bumped crate to 0.3.3 and updated changelog
- **🛠️ MSRV**: pinned dev-dependency tempfile to 3.21 to avoid transitive raises in compiler requirements

## ✅ Compatibility
- ✅ No breaking changes
- ✅ Public APIs unchanged
- ✅ Behavior unchanged; this release focuses on clearer docs and stronger tests

## 🦀 MSRV and dependencies
- 📌 MSRV remains 1.70.0
- 📦 tempfile pinned to 3.21 under dev-dependencies to ensure MSRV compatibility

## 🔒 Security
- 🛡️ Existing ADS and CVE coverage retained; messaging clarified
- 🔐 No policy or validation changes

## 🎯 Quality gates
- 📊 Docs updated to reflect 301 tests total
- ✅ MSRV check expected to pass after lockfile regeneration on 1.70.0