### PR TITLE
Release v0.3.5 - Updated README.md with the renamed `jailed-path` to `stict-path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5] - 2025-09-13
+
+### Changed
+- Updated feature comparison table in README.md to reflect the new `strict-path` crate, replacing the previous `jailed-path` reference
+- Clarified "Anchored canonicalization" feature description as "Virtual/bounded canonicalization" for better terminology alignment
+- Version bump to 0.3.5
+
+### Documentation
+- Enhanced crate comparison clarity by updating the feature comparison table with more accurate descriptions of virtual/bounded path canonicalization capabilities
+
 ## [0.3.3] - 2025-09-09
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soft-canonicalize"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 description = "Path canonicalization that works with non-existing paths."

--- a/README.md
+++ b/README.md
@@ -129,24 +129,24 @@ The "soft" aspect means we can canonicalize paths even when the target doesn't e
 
 Each crate serves different use cases. Choose based on your primary need:
 
-| Crate                   | **Primary Purpose**                             | **Use Cases**                                                                     |
-| ----------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------- |
-| `soft_canonicalize`     | **Path canonicalization + non-existing paths**  | When you need `std::fs::canonicalize` behavior but for paths that don't exist yet |
-| `std::fs::canonicalize` | **Path canonicalization (existing paths only)** | Standard path canonicalization when all paths exist on filesystem                 |
-| `dunce::canonicalize`   | **Windows compatibility layer**                 | Fixing Windows UNC issues for legacy app compatibility                            |
-| `normpath::normalize`   | **Safe normalization alternative**              | Avoiding Windows UNC bugs while normalizing paths                                 |
-| `path_absolutize`       | **CWD-relative path resolution**                | Converting relative paths to absolute with performance optimization               |
-| `jailed-path`           | **Security-first path containment**             | Preventing directory traversal attacks in web servers/sandboxes                   |
+| Crate                   | **Primary Purpose**                               | **Use Cases**                                                                     |
+| ----------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `soft_canonicalize`     | **Path canonicalization + non-existing paths**    | When you need `std::fs::canonicalize` behavior but for paths that don't exist yet |
+| `std::fs::canonicalize` | **Path canonicalization (existing paths only)**   | Standard path canonicalization when all paths exist on filesystem                 |
+| `dunce::canonicalize`   | **Windows compatibility layer**                   | Fixing Windows UNC issues for legacy app compatibility                            |
+| `normpath::normalize`   | **Safe normalization alternative**                | Avoiding Windows UNC bugs while normalizing paths                                 |
+| `path_absolutize`       | **CWD-relative path resolution**                  | Converting relative paths to absolute with performance optimization               |
+| `strict-path`           | **Type-safe path restriction with safe symlinks** | Preventing directory traversal with type-safe path restriction and safe symlinks  |
 
 ### Feature Comparison
 
-| Feature                       | `soft_canonicalize`         | `std::fs::canonicalize` | `dunce::canonicalize` | `normpath::normalize` | `path_absolutize` | `jailed-path`       |
-| ----------------------------- | --------------------------- | ----------------------- | --------------------- | --------------------- | ----------------- | ------------------- |
-| Works with non-existing paths | ✅                           | ❌                       | ❌                     | ✅                     | ✅                 | ✅ (via this crate)  |
-| Resolves symlinks             | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ✅ (via this crate)  |
-| Windows UNC path support      | ✅                           | ✅                       | ✅                     | ✅                     | ❌                 | ✅ (via this crate)  |
-| Zero dependencies             | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ❌ (uses this crate) |
-| Anchored canonicalization     | ✅ (`anchored_canonicalize`) | ❌                       | ❌                     | ❌                     | ❌                 | ❌                   |
+| Feature                          | `soft_canonicalize`         | `std::fs::canonicalize` | `dunce::canonicalize` | `normpath::normalize` | `path_absolutize` | `strict-path`       |
+| -------------------------------- | --------------------------- | ----------------------- | --------------------- | --------------------- | ----------------- | ------------------- |
+| Works with non-existing paths    | ✅                           | ❌                       | ❌                     | ✅                     | ✅                 | ✅ (via this crate)  |
+| Resolves symlinks                | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ✅ (via this crate)  |
+| Windows UNC path support         | ✅                           | ✅                       | ✅                     | ✅                     | ❌                 | ✅ (via this crate)  |
+| Zero dependencies                | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ❌ (uses this crate) |
+| Virtual/bounded canonicalization | ✅ (`anchored_canonicalize`) | ❌                       | ❌                     | ❌                     | ❌                 | ✅ (`PathBoundary`)  |
 
 ## Known Limitations
 


### PR DESCRIPTION
# Release v0.3.5

## What's Changed
- Updated README comparison table: replaced `jailed-path` with `strict-path` crate
- Renamed "Anchored canonicalization" to "Virtual/bounded canonicalization" 
- Version bump to 0.3.5

Documentation-only release with no functional changes.

**Full Changelog**: https://github.com/DK26/soft-canonicalize-rs/compare/v0.3.4...v0.3.5