### PR TITLE
Fix v0.3.6: Correct strict-path comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2025-09-15
+
+### Fixed
+- Corrected `strict-path` feature comparison: `VirtualRoot` (not `PathBoundary`) is the correct equivalent to our `anchored_canonicalize` functionality
+
 ## [0.3.5] - 2025-09-13
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soft-canonicalize"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 description = "Path canonicalization that works with non-existing paths."

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Each crate serves different use cases. Choose based on your primary need:
 | Resolves symlinks                | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ✅ (via this crate)  |
 | Windows UNC path support         | ✅                           | ✅                       | ✅                     | ✅                     | ❌                 | ✅ (via this crate)  |
 | Zero dependencies                | ✅                           | ✅                       | ✅                     | ❌                     | ❌                 | ❌ (uses this crate) |
-| Virtual/bounded canonicalization | ✅ (`anchored_canonicalize`) | ❌                       | ❌                     | ❌                     | ❌                 | ✅ (`PathBoundary`)  |
+| Virtual/bounded canonicalization | ✅ (`anchored_canonicalize`) | ❌                       | ❌                     | ❌                     | ❌                 | ✅ (`VirtualRoot`)   |
 
 ## Known Limitations
 


### PR DESCRIPTION
# Fix v0.3.6: Correct strict-path comparison

## What's Changed
- Fixed feature comparison table: `VirtualRoot` (not `PathBoundary`) is the correct equivalent to our `anchored_canonicalize`
- Version bump to 0.3.6

## Why This Fix
The previous comparison incorrectly listed `PathBoundary` as the equivalent feature. `VirtualRoot` provides the actual virtual root semantics that match our anchored canonicalization functionality.

**Files Changed:**
- `README.md`: Corrected comparison table
- `Cargo.toml`: Version bump to 0.3.6  
- `CHANGELOG.md`: Added v0.3.6 entry

**Type:** Documentation fix  
**Breaking Changes:** None