### PR TITLE
Release v0.5.6: Windows prefix-mismatch fixes and NUL/UNC security hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,56 @@ These scripts:
 2. If these tests compare with `std::fs::canonicalize` without feature-conditional assertions, they will FAIL in CI when dunce feature is enabled
 3. You won't catch these failures until after you push to GitHub
 
+### Junction Fallback — the Preferred Remedy, Not Plain Skip
+
+A test that merely skips on error 1314 is a CI-only test: the developer never
+sees it pass on their own machine and cannot reproduce a CI failure locally.
+When the behavior under test does not require true symlink semantics
+(reparse-point resolution is sufficient), use an NTFS **junction** as a
+fallback so the test runs on non-admin Windows sessions too.
+
+**Rules:**
+
+1. **Use the existing helper, don't inline** — a `create_symlink_or_junction`
+   helper already lives in `tests/test_helpers/`. Integration tests under
+   `tests/` must call that helper rather than re-implementing the try-symlink-
+   then-junction pattern. If you find yourself writing `match symlink_dir(...)
+   { Err(e) if ... raw_os_error() == Some(1314) => junction_verbatim::create
+   (...) }` by hand in an integration test, stop and use the helper.
+
+2. **`src/tests/` unit tests** can't import the helper (different crate
+   boundary). For those, either: (a) move the test to `tests/` and use the
+   helper, or (b) inline the two-arm fallback with the `junction-verbatim`
+   dev-dependency. Do NOT add a second module that re-exports a parallel
+   helper; one canonical helper per repo.
+
+3. **Junction semantic gotcha**: junctions require an ABSOLUTE target and can
+   only point at directories on the same volume. Symlinks accept both
+   relative and absolute targets. When designing a test that must work via
+   either mechanism, structure it with an absolute target so the same setup
+   works for both — don't write two parallel tests for the "symlink only" and
+   "junction only" cases.
+
+4. **When junction is not an acceptable fallback**: tests that specifically
+   exercise relative-symlink target resolution, or absolute symlink targets
+   outside the anchor's volume, must remain symlink-only and skip on 1314.
+   Document why junction won't satisfy the test in a short comment.
+
+5. **Do not replace or alter an existing regression test with a junction
+   variant**. Junction covers a different code path (absolute-target reparse
+   point) than a relative symlink. If both paths matter, ADD a sibling test;
+   never rename or rewrite the original. Regression tests are append-only —
+   the name and assertions at release time must survive intact so future
+   bisects can pinpoint behaviour changes.
+
+6. **Verify the test actually ran locally.** A test that prints "skipping:
+   symlink creation not permitted" and returns `Ok(())` is not evidence of
+   correctness. When reporting a fix, confirm via the test runner's output
+   (`... ok` with execution time) that the test body executed. If every
+   relevant test printed a skip line, you have no local proof — add a
+   junction fallback (as a SIBLING test per rule 5) or run in an elevated /
+   Developer-Mode session before claiming the fix works.
+
 **How to Identify These Tests**:
 Search for these patterns in test files:
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,76 @@ For necessary allocations (variable-length output):
 - Keep struct fields private when invariants must be enforced.  Expose
   transition methods that enforce them.
 
+### Lifetime Naming
+
+**Every named lifetime parameter must have a descriptive name that explains
+whose lifetime it represents.**  Single-letter lifetimes (`'a`, `'b`, `'c`,
+...) are **banned** — no exceptions, no "simple signature" carve-out.
+
+Name lifetimes after the data they bind to: `'path`, `'input`, `'src`,
+`'buf`, `'anchor`, `'cfg`, `'err`.  When a function takes two references,
+give each one a name that identifies its source (e.g. `fn f<'input, 'buf>
+(src: &'input str, dst: &'buf mut String)`).
+
+Exceptions (these are not "single-letter" names, they are language built-ins):
+
+- `'static` — Rust's built-in lifetime for program-long data.  Use it when
+  the borrow must outlive the process.
+- `'_` — the elided / anonymous lifetime.  Use it only where the compiler
+  already infers the lifetime and naming it would add no information
+  (e.g. `fmt::Formatter<'_>`).  Prefer a real name whenever the lifetime
+  appears in a function or type signature you author.
+
+**Why:** lifetimes are a contract between the caller and the function about
+who owns what for how long.  A name like `'a` forces every reader to
+reverse-engineer that contract from the signature.  A name like `'anchor`
+tells them instantly — the same way a well-named parameter does.  Stale
+single-letter names rot fastest: add a second lifetime and now `'a` and
+`'b` are a puzzle.  Descriptive names never rot.
+
+### Comments Explain Reasoning, Not Mechanics
+
+Comments must answer **why**: the reasoning, invariant, security property,
+non-obvious constraint, or history behind a workaround.  Never comment what
+the code already says — well-named identifiers are the canonical "what".
+
+- Good: `// SECURITY: clamp before join — raw target may contain ".." that`
+  `// escape the anchor when the OS resolves the returned path.`
+- Good: `// Fast-path: skip fs::canonicalize when lexical form is unchanged;`
+  `// avoids a syscall in the hot case.`
+- Bad: `// increment counter` above `counter += 1;`
+- Bad: `// call the helper` above a function call.
+
+When in doubt, add a short comment stating the invariant/reason.  A future
+reader (human or agent) who asks "why is this here?" must find the answer in
+the code — not in a commit message, issue tracker, or vanished conversation.
+Delete comments that only restate identifiers.
+
+### Doc Comment Discipline
+
+Doc comments (`///`, `//!`) must never hide executable content from the test
+harness.  **Forbidden fence styles in Rust doc comments** (they are all
+treated as test-skip or test-bypass mechanisms):
+
+- ` ```text ` — blocks code from compiling.  Use plain prose (no fence) or a
+  bulleted list instead.  For pseudocode illustrations, write them as prose.
+- ` ```ignore `, ` ```no_run `, ` ```should_panic `, ` ```compile_fail ` —
+  block or redirect execution.  Rewrite as a real runnable ` ```rust ` block
+  that `cargo test --doc` compiles and runs, or move the illustration into
+  a regular `#[test]` and reference it from the doc comment.
+
+Rules of thumb:
+
+- **Pseudocode** → write it as prose (no fence).
+- **Runnable Rust** → use the default ` ``` ` or ` ```rust ` fence and make
+  it actually compile and run under `cargo test --doc`.
+- **Private / `pub(crate)` items**: rustdoc does not execute their doctests,
+  so a ` ```rust ` block there is a lie that cannot be verified.  Use prose.
+
+This discipline applies to every Rust source file.  Plain Markdown files
+(`README.md`, `CONTRIBUTING.md`, `CHANGELOG.md`) may use ` ```text ` freely —
+they are not processed by rustdoc.
+
 ### RAG / LLM-Friendly File Size
 
 Keep source files under **~600 lines** (production or test) to fit within a
@@ -553,7 +623,11 @@ We track test count as the sum of:
 - Number of `#[test]` items found under `src/` and `tests/` folders
 - Plus the number of Rust doc tests
 
-**Important**: Doc tests must be runnable. Do not use `no_run`, `ignore`, `should_panic`, or other attributes that prevent execution. All doc tests must compile and run successfully as part of `cargo test`.
+**Important**: Doc tests must be runnable.  See "Doc Comment Discipline"
+under Coding Guidelines for the authoritative rule — in short, the fences
+` ```text `, `no_run`, `ignore`, `should_panic`, and `compile_fail` are
+all banned in Rust doc comments.  All doc tests must compile and run
+successfully as part of `cargo test`.
 
 Commands to count tests:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.6] - 2026-04-19
+
+### Security
+
+- **NUL-byte detection now always path-aware**: Moved `reject_nul_bytes` to Stage 0 of `soft_canonicalize` and added a final pass on the output. Guarantees that `IoErrorPathExt::soft_canon_detail()` consistently returns the path-aware `"path contains null byte"` detail instead of stdlib's generic `InvalidInput`, even when a NUL enters via symlink-target resolution.
+- **Fixed `anchored_canonicalize` escape via absolute `..` symlink targets**: Absolute symlink targets that began with `..` could escape the anchor. Extracted `normalize_and_clamp_to_anchor` so every clamp site in the crate uses the same `..`-normalizing, common-prefix-clamping logic.
+- **Forward-slash UNC rejection**: `is_incomplete_unc` now detects forward-slash forms (`//server`) and mixed-separator variants, while still correctly excluding verbatim (`\\?\`) and device (`\\.\`) namespaces for both separator kinds.
+- **Upgraded `proc-canonicalize` 0.1.2 → 0.1.3**: pulls in the upstream fix for a namespace-boundary bypass where paths like `/proc/<PID>/../<PID>/root` lexically normalized to `/proc/<PID>/root` but evaded detection; the scanner now performs lexical normalization before boundary detection. Also includes an indirect-symlink scanner performance improvement (hoisted scratch buffers eliminate per-iteration heap allocations).
+
+### Fixed
+
+- **Windows: `simple_normalize_path` now preserves `VerbatimDisk` prefix**: Building `\\?\` then pushing a drive letter silently dropped the verbatim marker, producing a `Prefix::Disk` output. Since `Path::starts_with` treats `Disk` and `VerbatimDisk` as distinct, anchored-symlink clamp checks against a verbatim floor would fail. Fixed by constructing the verbatim path as a single `PathBuf::from(format!(r"\\?\{drive}\"))`. Drive-relative inputs (`C:foo`) still skip the verbatim prefix to preserve per-drive CWD semantics.
+- **Windows: `anchored_canonicalize` `..` pop skipped on `Disk` vs `VerbatimDisk` prefix mismatch**: When `soft_canonicalize` returned a `Disk`-prefixed anchor floor (with the `dunce` feature) but symlink resolution brought the working path back through `fs::canonicalize` as `VerbatimDisk`, the stdlib `Path::starts_with` gate returned false, silently skipping the `..` pop and leaking the pre-`..` component into the final result. Now uses a component-wise `is_strictly_below` predicate built on the crate's `component_eq` helper, which equates the two prefix forms.
+
+### Added
+
+- **`component_eq` helper** (Windows-aware): treats `VerbatimDisk` vs `Disk` and `VerbatimUNC` vs `UNC` as equal, case-insensitive for drive letters and UNC server/share.
+- **`normalize_and_clamp_to_anchor` helper**: single source of truth for the `..`-normalizing, common-prefix-clamping logic used across the anchored code paths.
+- **Regression tests**:
+  - `tests/anchored_absolute_symlink_dotdot_escape.rs` — covers the anchored `..` escape fix for absolute symlink targets.
+  - `tests/regression_nul_byte_error_detail.rs` — pins the path-aware `soft_canon_detail()` output.
+  - `tests/regression_incomplete_unc_forward_slash.rs` — pins forward-slash UNC rejection.
+  - `anchored_security::windows_symlink::anchored_symlink_or_junction_keeps_clamp_windows` (sibling to `anchored_relative_symlink_keeps_clamp_windows`) — uses a directory symlink with NTFS-junction fallback on error 1314 so non-admin / non-Developer-Mode Windows sessions still exercise the anchor `..` pop via a real reparse point.
+  - `normalize::verbatim_prefix_regression` and `symlink::clamp_verbatim_regression` — pin `VerbatimDisk` preservation through normalization and clamping without requiring symlink-create privileges.
+- **AGENTS.md "Junction Fallback" rules**: codifies the pattern so tests exercise the code path locally via NTFS junctions (`create_symlink_or_junction` helper for integration tests, inline junction fallback for unit tests) instead of silently skipping on error 1314.
+
+### Changed
+
+- **AGENTS.md rewrite**: reorganized around maintenance principles (general-not-reactive, context-free rules, principles-over-examples), with expanded guidance on feature testing policy, symlink testing traps, git usage, coding guidelines, and test assertion style.
+- **Test reorganization**: split `unicode` and `windows_8_3` unit tests into thematic files for better readability and RAG retrieval.
+- **CI — cross-platform Clippy**: `ci-local.sh` and `ci-local.ps1` now run clippy against the complement target (`x86_64-unknown-linux-gnu` on Windows, `x86_64-pc-windows-gnu` on Linux), so cfg-gated files for the opposite platform are linted locally before hitting CI.
+
 ## [0.5.5] - 2026-04-04
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.70.0"
 [dependencies]
 # Optional: fixes std::fs::canonicalize for Linux /proc/PID/root magic symlinks.
 # Enabled by default. Disable with `default-features = false` if you need std behavior.
-proc-canonicalize = { version = "0.1.2", optional = true }
+proc-canonicalize = { version = "0.1.3", optional = true }
 
 # Optional dunce dependency for path simplification (Windows-only)
 [target.'cfg(windows)'.dependencies]
@@ -36,7 +36,7 @@ tempfile = "=3.21" # Do not update
 # us to bump our MSRV to Rust 1.71, and we only use this crate for testing.
 # So, we stick to the workaround `junction-verbatim`
 # Do not bump to `1.3.1` or we will get deprecation warnings about `junction-verbatim` crate.
-junction-verbatim = "=1.3.0"
+junction-verbatim = "=1.3.0" # Do not update
 
 [features]
 default = ["proc-canonicalize"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "soft-canonicalize"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 authors = ["David Krasnitsky <dikaveman@gmail.com>"]
 description = "Path canonicalization that works with non-existing paths."

--- a/ci-local.ps1
+++ b/ci-local.ps1
@@ -206,6 +206,22 @@ Write-Host ""
 # Run all CI checks in order
 Run-Check "Format Check" "cargo fmt --all -- --check"
 Run-Check "Clippy Lint" "cargo clippy --all-targets --all-features -- -D warnings"
+
+# Cross-platform Clippy: host clippy skips files gated for the OTHER platform
+# (e.g., tests starting with `#![cfg(unix)]` compile to nothing on Windows, so
+# clippy never lints them). Run clippy against the complement target so issues
+# like `needless_borrow` in cross-platform test files are caught before CI.
+if ($env:OS -eq "Windows_NT") {
+    $crossTarget = "x86_64-unknown-linux-gnu"
+} else {
+    $crossTarget = "x86_64-pc-windows-gnu"
+}
+Write-Host "Ensuring cross-platform target '$crossTarget' is installed..." -ForegroundColor Cyan
+$oldEA = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+& rustup target add $crossTarget 2>&1 | Out-Null
+$ErrorActionPreference = $oldEA
+Run-Check "Cross-platform Clippy ($crossTarget)" "cargo clippy --target $crossTarget --all-targets --all-features -- -D warnings"
+
 # Skip 'cargo check' since 'cargo test' compiles everything anyway
 # Set SKIP_PERMISSION_TESTS for local testing (symlinks may require admin/Developer Mode)
 $env:SKIP_PERMISSION_TESTS = "1"
@@ -285,6 +301,10 @@ if (Get-Command rustup -ErrorAction SilentlyContinue) {
                 Write-Host "  SUCCESS: Cargo.lock regenerated successfully" -ForegroundColor Green
                 Run-Check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
                 Run-Check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+                $oldEA2 = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+                & rustup target add $crossTarget --toolchain 1.70.0 2>&1 | Out-Null
+                $ErrorActionPreference = $oldEA2
+                Run-Check "MSRV Cross-platform Clippy ($crossTarget)" "rustup run 1.70.0 cargo clippy --target $crossTarget --all-targets --all-features -- -D warnings"
             } else {
                 throw "generate-lockfile failed"
             }
@@ -293,6 +313,8 @@ if (Get-Command rustup -ErrorAction SilentlyContinue) {
             Write-Host "  INFO: Trying fallback: cargo update then check" -ForegroundColor Yellow
             Run-Check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
             Run-Check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+            & rustup target add $crossTarget --toolchain 1.70.0 2>&1 | Out-Null
+            Run-Check "MSRV Cross-platform Clippy ($crossTarget)" "rustup run 1.70.0 cargo clippy --target $crossTarget --all-targets --all-features -- -D warnings"
         }
     } else {
         Write-Host "WARNING: Rust 1.70.0 not installed. Installing for MSRV check..." -ForegroundColor Yellow
@@ -315,6 +337,10 @@ if (Get-Command rustup -ErrorAction SilentlyContinue) {
                         Run-Fix "MSRV Clippy Auto-fix" "rustup run 1.70.0 cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features"
                         Run-Check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
                         Run-Check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+                        $oldEA2 = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+                & rustup target add $crossTarget --toolchain 1.70.0 2>&1 | Out-Null
+                $ErrorActionPreference = $oldEA2
+                        Run-Check "MSRV Cross-platform Clippy ($crossTarget)" "rustup run 1.70.0 cargo clippy --target $crossTarget --all-targets --all-features -- -D warnings"
                     } else {
                         throw "generate-lockfile failed"
                     }
@@ -324,6 +350,10 @@ if (Get-Command rustup -ErrorAction SilentlyContinue) {
                     Run-Fix "MSRV Clippy Auto-fix" "rustup run 1.70.0 cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features"
                     Run-Check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
                     Run-Check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+                    $oldEA2 = $ErrorActionPreference; $ErrorActionPreference = "Continue"
+                & rustup target add $crossTarget --toolchain 1.70.0 2>&1 | Out-Null
+                $ErrorActionPreference = $oldEA2
+                    Run-Check "MSRV Cross-platform Clippy ($crossTarget)" "rustup run 1.70.0 cargo clippy --target $crossTarget --all-targets --all-features -- -D warnings"
                 }
             } else {
                 throw "toolchain install failed"

--- a/ci-local.sh
+++ b/ci-local.sh
@@ -229,6 +229,20 @@ echo
 # Run all CI checks in order
 run_check "Format Check" "cargo fmt --all -- --check"
 run_check "Clippy Lint" "cargo clippy --all-targets --all-features -- -D warnings"
+
+# Cross-platform Clippy: host clippy skips files gated for the OTHER platform
+# (e.g., tests starting with `#![cfg(unix)]` compile to nothing on Windows, so
+# clippy never lints them). Run clippy against the complement target so issues
+# like `needless_borrow` in cross-platform test files are caught before CI.
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
+    CROSS_TARGET="x86_64-unknown-linux-gnu"
+else
+    CROSS_TARGET="x86_64-pc-windows-gnu"
+fi
+echo "Ensuring cross-platform target '$CROSS_TARGET' is installed..."
+rustup target add "$CROSS_TARGET" >/dev/null 2>&1 || true
+run_check "Cross-platform Clippy ($CROSS_TARGET)" "cargo clippy --target $CROSS_TARGET --all-targets --all-features -- -D warnings"
+
 # Skip 'cargo check' since 'cargo test' compiles everything anyway
 # Set SKIP_PERMISSION_TESTS for local testing (symlinks may require admin/Developer Mode)
 export SKIP_PERMISSION_TESTS=1
@@ -303,12 +317,16 @@ if command -v rustup &> /dev/null; then
             run_fix "MSRV Clippy Auto-fix" "rustup run 1.70.0 cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features"
             run_check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
             run_check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+            rustup target add "$CROSS_TARGET" --toolchain 1.70.0 >/dev/null 2>&1 || true
+            run_check "MSRV Cross-platform Clippy ($CROSS_TARGET)" "rustup run 1.70.0 cargo clippy --target $CROSS_TARGET --all-targets --all-features -- -D warnings"
         else
             echo "  ❌ Failed to generate Cargo.lock with Rust 1.70.0"
             echo "  💡 Trying fallback: cargo update then check"
             run_fix "MSRV Clippy Auto-fix" "rustup run 1.70.0 cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features"
             run_check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
             run_check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+            rustup target add "$CROSS_TARGET" --toolchain 1.70.0 >/dev/null 2>&1 || true
+            run_check "MSRV Cross-platform Clippy ($CROSS_TARGET)" "rustup run 1.70.0 cargo clippy --target $CROSS_TARGET --all-targets --all-features -- -D warnings"
         fi
     else
         echo "⚠️  Rust 1.70.0 not installed. Installing for MSRV check..."
@@ -327,12 +345,16 @@ if command -v rustup &> /dev/null; then
                 run_fix "MSRV Clippy Auto-fix" "rustup run 1.70.0 cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features"
                 run_check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
                 run_check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+                rustup target add "$CROSS_TARGET" --toolchain 1.70.0 >/dev/null 2>&1 || true
+                run_check "MSRV Cross-platform Clippy ($CROSS_TARGET)" "rustup run 1.70.0 cargo clippy --target $CROSS_TARGET --all-targets --all-features -- -D warnings"
             else
                 echo "  ❌ Failed to generate Cargo.lock with Rust 1.70.0"
                 echo "  💡 Trying fallback: cargo update then check"
                 run_fix "MSRV Clippy Auto-fix" "rustup run 1.70.0 cargo clippy --fix --allow-dirty --allow-staged --all-targets --all-features"
                 run_check "MSRV Check (Rust 1.70.0)" "rustup run 1.70.0 cargo check --verbose"
                 run_check "MSRV Clippy Lint" "rustup run 1.70.0 cargo clippy --all-targets --all-features -- -D warnings"
+                rustup target add "$CROSS_TARGET" --toolchain 1.70.0 >/dev/null 2>&1 || true
+                run_check "MSRV Cross-platform Clippy ($CROSS_TARGET)" "rustup run 1.70.0 cargo clippy --target $CROSS_TARGET --all-targets --all-features -- -D warnings"
             fi
         else
             echo "❌ Failed to install Rust 1.70.0. Skipping MSRV check."

--- a/src/anchored.rs
+++ b/src/anchored.rs
@@ -2,10 +2,25 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use crate::error::error_with_path;
+use crate::symlink::component_eq;
 #[cfg(windows)]
 use crate::windows::{
     ensure_windows_extended_prefix, is_incomplete_unc, validate_windows_ads_layout,
 };
+
+/// True iff `path` has a strict component-prefix of `floor` and at least one
+/// component beyond it, using `component_eq` (so `Disk(C)` ~ `VerbatimDisk(C)`).
+/// This is the anchor-floor predicate for `..` pops in `anchored_canonicalize`.
+fn is_strictly_below(path: &Path, floor: &Path) -> bool {
+    let mut p = path.components();
+    for fc in floor.components() {
+        match p.next() {
+            Some(c) if component_eq(&c, &fc) => continue,
+            _ => return false,
+        }
+    }
+    p.next().is_some()
+}
 
 /// Canonicalize a user-provided path relative to an anchor directory, with virtual filesystem semantics.
 ///
@@ -221,8 +236,15 @@ pub fn anchored_canonicalize(
                 }
             }
             Component::ParentDir => {
-                // Clamp ".." to anchor boundary
-                if base != anchor_floor && base.starts_with(&anchor_floor) {
+                // Pop only when `base` is STRICTLY below the floor. We compare
+                // component-wise with `component_eq` so that a `Disk(C)` floor
+                // matches a `VerbatimDisk(C)` base (or vice versa): `soft_canonicalize`
+                // can return either form depending on the `dunce` feature and on
+                // whether symlink resolution re-entered via `fs::canonicalize`,
+                // and the stdlib `Path::starts_with` treats those as non-equal.
+                // Using the naive check silently skipped the pop, leaving the
+                // pre-`..` component in the result.
+                if is_strictly_below(&base, &anchor_floor) {
                     let _ = base.pop();
                 }
             }

--- a/src/anchored.rs
+++ b/src/anchored.rs
@@ -205,42 +205,18 @@ pub fn anchored_canonicalize(
             Component::Normal(seg) => {
                 base.push(seg);
 
-                // Resolve symlink chain at `base` using anchor-aware resolver
+                // Resolve symlink chain at `base` using anchor-aware resolver, then funnel
+                // through the shared clamp helper so every anchor-clamping site in the crate
+                // uses the same component-aware, `..`-normalizing logic.  The resolver already
+                // clamps internally, but this final pass is defense-in-depth — if a future
+                // code path bypasses the internal clamp, the escape still cannot reach `base`.
                 if let Ok(meta) = std::fs::symlink_metadata(&base) {
                     if meta.file_type().is_symlink() {
-                        // Use anchored symlink resolver that implements virtual filesystem semantics
                         let resolved =
                             crate::symlink::resolve_anchored_symlink_chain(&base, &anchor_floor)?;
-
-                        // Final safety check: ensure resolved path is within anchor
-                        if !resolved.starts_with(&anchor_floor) {
-                            // Virtual filesystem semantics: reinterpret escaped path as relative to anchor
-                            // Find common ancestor and preserve relative path structure
-                            // Example: resolved = /tmp/xyz/opt/file, anchor = /tmp/xyz/home/jail
-                            // Common ancestor: /tmp/xyz
-                            // Resolved relative to common: opt/file
-                            // Result: /tmp/xyz/home/jail/opt/file
-
-                            // Find longest common prefix by comparing components
-                            let mut common_depth = 0;
-                            let anchor_comps: Vec<_> = anchor_floor.components().collect();
-                            let resolved_comps: Vec<_> = resolved.components().collect();
-                            for (a, r) in anchor_comps.iter().zip(resolved_comps.iter()) {
-                                if a == r {
-                                    common_depth += 1;
-                                } else {
-                                    break;
-                                }
-                            }
-
-                            // Build clamped path: anchor + (resolved components after common prefix)
-                            base = anchor_floor.clone();
-                            for comp in resolved_comps.iter().skip(common_depth) {
-                                base.push(comp);
-                            }
-                        } else {
-                            base = resolved;
-                        }
+                        let (clamped, _was_clamped) =
+                            crate::symlink::normalize_and_clamp_to_anchor(&resolved, &anchor_floor);
+                        base = clamped;
                     }
                 }
             }
@@ -286,6 +262,10 @@ pub fn anchored_canonicalize(
     {
         base = dunce::simplified(&base).to_path_buf();
     }
+
+    // Final: defense-in-depth — reject any NUL that may have entered via symlink
+    // target resolution. See `soft_canonicalize` for the rationale.
+    crate::reject_nul_bytes(&base)?;
 
     Ok(base)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,13 @@ pub fn soft_canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
         ));
     }
 
+    // Stage 0: reject NUL bytes before any FS contact.
+    // Why: stdlib's canonicalize also rejects NULs, but moving the check here
+    // guarantees our path-aware detail ("path contains null byte") is always
+    // observable via `IoErrorPathExt::soft_canon_detail()`, independent of
+    // stdlib behavior.
+    reject_nul_bytes(path)?;
+
     // Windows-only: explicit guard — reject incomplete UNC roots (\\server without a share)
     #[cfg(windows)]
     {
@@ -486,9 +493,6 @@ pub fn soft_canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
         }
     }
     // At this point: path doesn't fully exist or canonicalize returned a recoverable error — continue.
-
-    // Stage 3.1: sanity check — validate no embedded NUL bytes (platform-specific)
-    reject_nul_bytes(path)?;
 
     // Stage 4: collect path components efficiently (root/prefix vs normal names)
     let mut components = Vec::new();
@@ -618,6 +622,12 @@ pub fn soft_canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
     {
         result = dunce::simplified(&result).to_path_buf();
     }
+
+    // Stage Final: defense-in-depth — reject any NUL that may have entered via
+    // symlink target resolution or other FS returns. Standard FS APIs forbid
+    // NULs, so this should never fire; the check guarantees callers can treat
+    // the returned path as NUL-free for display, logging, or further processing.
+    reject_nul_bytes(&result)?;
 
     Ok(result)
 }

--- a/src/normalize.rs
+++ b/src/normalize.rs
@@ -152,11 +152,26 @@ pub(crate) fn simple_normalize_path(path: &std::path::Path) -> PathBuf {
                 return ext;
             }
             Anchor::Drive(ref drive) => {
-                let mut ext = PathBuf::from(r"\\?\");
-                ext.push(drive);
                 if has_root_dir {
-                    ext.push(Component::RootDir.as_os_str());
+                    // Build `\\?\C:\...` in a single `PathBuf::from` so it parses
+                    // as `Prefix::VerbatimDisk`. The naive form —
+                    // `PathBuf::from(r"\\?\")` then `push(drive)` — silently
+                    // drops the verbatim marker and the result parses as
+                    // `Prefix::Disk`. That mismatch made the clamp output fail
+                    // `starts_with` against a true-verbatim anchor floor.
+                    let drive_str = drive.to_string_lossy();
+                    let mut ext = PathBuf::from(format!(r"\\?\{drive_str}\"));
+                    for seg in stack {
+                        ext.push(seg);
+                    }
+                    return ext;
                 }
+                // Drive-relative (`C:foo`): preserve drive-relative semantics so
+                // downstream `fs::canonicalize` can resolve against the
+                // per-drive CWD. Adding a verbatim prefix here would turn it
+                // into an absolute path rooted at `C:\`.
+                let mut ext = PathBuf::new();
+                ext.push(drive);
                 for seg in stack {
                     ext.push(seg);
                 }
@@ -194,5 +209,67 @@ pub(crate) fn simple_normalize_path(path: &std::path::Path) -> PathBuf {
         }
 
         result
+    }
+}
+
+#[cfg(all(test, windows))]
+mod verbatim_prefix_regression {
+    use super::simple_normalize_path;
+    use std::path::{Component, Path, Prefix};
+
+    fn prefix_kind(p: &Path) -> Option<Prefix<'_>> {
+        p.components().next().and_then(|c| match c {
+            Component::Prefix(pc) => Some(pc.kind()),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn verbatim_disk_input_yields_verbatim_disk_output() {
+        let input = Path::new(r"\\?\C:\Users\runneradmin\AppData\Local\Temp\.tmpAAAA\home\jail");
+        let out = simple_normalize_path(input);
+        match prefix_kind(&out) {
+            Some(Prefix::VerbatimDisk(b'C')) => {}
+            other => panic!(
+                "simple_normalize_path must preserve VerbatimDisk; got {:?} for output {:?}",
+                other, out
+            ),
+        }
+    }
+
+    #[test]
+    fn verbatim_disk_with_dotdot_still_yields_verbatim_disk() {
+        // Simulates the anchored-symlink flow: a verbatim path with `..` segments
+        // that collapse but still leave a non-trivial tail. The output prefix
+        // must remain `VerbatimDisk` so callers using `Path::starts_with` against
+        // a verbatim anchor floor get the match they expect.
+        let input = Path::new(r"\\?\C:\a\b\c\..\..\d\e");
+        let out = simple_normalize_path(input);
+        match prefix_kind(&out) {
+            Some(Prefix::VerbatimDisk(b'C')) => {}
+            other => panic!(
+                "simple_normalize_path must preserve VerbatimDisk under `..`; got {:?} for output {:?}",
+                other, out
+            ),
+        }
+    }
+
+    #[test]
+    fn disk_starts_with_verbatim_disk_is_false_in_stdlib() {
+        // Pin the stdlib behavior this fix depends on: `Path::starts_with` is
+        // component-based and treats `Prefix::Disk('C')` and `Prefix::VerbatimDisk('C')`
+        // as non-equal. If this ever changes in stdlib, the regression above
+        // becomes moot — but we want to know.
+        let disk = Path::new(r"C:\foo\bar");
+        let verbatim = Path::new(r"\\?\C:\foo\bar");
+        assert!(matches!(prefix_kind(disk), Some(Prefix::Disk(_))));
+        assert!(matches!(
+            prefix_kind(verbatim),
+            Some(Prefix::VerbatimDisk(_))
+        ));
+        assert!(
+            !disk.starts_with(verbatim),
+            "stdlib changed: Disk now matches VerbatimDisk in starts_with — revisit clamp logic"
+        );
     }
 }

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -507,3 +507,62 @@ fn is_likely_system_symlink(path: &Path) -> bool {
 fn is_likely_system_symlink(_path: &Path) -> bool {
     false
 }
+
+#[cfg(all(test, windows, feature = "anchored"))]
+mod clamp_verbatim_regression {
+    //! Regression: `normalize_and_clamp_to_anchor` must return a path whose
+    //! prefix form matches the anchor's, so that downstream callers using
+    //! stdlib `Path::starts_with` (which treats `Disk` != `VerbatimDisk`) get
+    //! the match they expect.
+    //!
+    //! The CI-only failure in
+    //! `anchored_security::windows_symlink::anchored_relative_symlink_keeps_clamp_windows`
+    //! traced to this: when `is_within_anchor` was true, the function returned
+    //! the `simple_normalize_path` output directly, which used to come back
+    //! with `Disk` prefix even for a `VerbatimDisk` input. The caller's
+    //! `base.starts_with(&anchor_floor)` then returned false, the `..` clamp
+    //! was skipped, and the stale component leaked into the final path.
+    //!
+    //! This test exercises the clamp helper directly with a hand-built
+    //! verbatim path, so it triggers the exact failure path without needing
+    //! symlink creation privileges (which Windows denies in non-admin sessions,
+    //! silently skipping the integration test above).
+    use super::normalize_and_clamp_to_anchor;
+    use std::path::{Component, Path, Prefix};
+
+    fn first_prefix_kind(p: &Path) -> Option<Prefix<'_>> {
+        p.components().next().and_then(|c| match c {
+            Component::Prefix(pc) => Some(pc.kind()),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn verbatim_anchor_and_within_input_yields_verbatim_output() {
+        let anchor = Path::new(r"\\?\C:\Users\runneradmin\AppData\Local\Temp\.tmpAAAA\home\jail");
+        // `current` is anchor + opt/subdir/special — already within the anchor,
+        // which takes the `is_within_anchor = true` branch (the buggy one).
+        let current = Path::new(
+            r"\\?\C:\Users\runneradmin\AppData\Local\Temp\.tmpAAAA\home\jail\opt\subdir\special",
+        );
+
+        let (clamped, was_clamped) = normalize_and_clamp_to_anchor(current, anchor);
+
+        assert!(
+            !was_clamped,
+            "input lies within anchor; clamp helper should signal no reclamp"
+        );
+        assert!(
+            matches!(first_prefix_kind(&clamped), Some(Prefix::VerbatimDisk(b'C'))),
+            "clamped output must preserve VerbatimDisk so stdlib starts_with works; got {:?} for {:?}",
+            first_prefix_kind(&clamped),
+            &clamped
+        );
+        assert!(
+            clamped.starts_with(anchor),
+            "stdlib Path::starts_with must match the anchor; got clamped={:?}, anchor={:?}",
+            &clamped,
+            anchor
+        );
+    }
+}

--- a/src/symlink.rs
+++ b/src/symlink.rs
@@ -52,6 +52,78 @@ pub(crate) fn strip_root_prefix(path: &Path) -> PathBuf {
     }
 }
 
+/// Component-wise equality that treats Windows `VerbatimDisk(X)` and `Disk(X)` as
+/// equivalent (same for `VerbatimUNC` vs `UNC`, case-insensitive for drive letters
+/// and UNC server/share). On non-Windows this is a plain `==`.
+#[cfg(feature = "anchored")]
+#[inline]
+pub(crate) fn component_eq(a: &std::path::Component, b: &std::path::Component) -> bool {
+    #[cfg(windows)]
+    {
+        use std::path::{Component, Prefix};
+        match (a, b) {
+            (Component::Prefix(ap), Component::Prefix(bp)) => match (ap.kind(), bp.kind()) {
+                (Prefix::VerbatimDisk(ad), Prefix::Disk(bd))
+                | (Prefix::Disk(ad), Prefix::VerbatimDisk(bd))
+                | (Prefix::VerbatimDisk(ad), Prefix::VerbatimDisk(bd))
+                | (Prefix::Disk(ad), Prefix::Disk(bd)) => ad.eq_ignore_ascii_case(&bd),
+                (Prefix::VerbatimUNC(as1, as2), Prefix::UNC(bs1, bs2))
+                | (Prefix::UNC(as1, as2), Prefix::VerbatimUNC(bs1, bs2))
+                | (Prefix::VerbatimUNC(as1, as2), Prefix::VerbatimUNC(bs1, bs2))
+                | (Prefix::UNC(as1, as2), Prefix::UNC(bs1, bs2)) => {
+                    as1.eq_ignore_ascii_case(bs1) && as2.eq_ignore_ascii_case(bs2)
+                }
+                _ => ap == bp,
+            },
+            _ => a == b,
+        }
+    }
+    #[cfg(not(windows))]
+    {
+        a == b
+    }
+}
+
+/// Normalize `current` and clamp it inside `anchor`.
+///
+/// - Collapses `.` and `..` segments lexically (so literal `..` from a raw symlink
+///   target cannot escape when the OS later resolves the returned path).
+/// - If the normalized path is not within `anchor`, rebuilds it as
+///   `anchor + (current components after longest common prefix)`.
+///
+/// Returns `(clamped_path, was_clamped)`.
+#[cfg(feature = "anchored")]
+pub(crate) fn normalize_and_clamp_to_anchor(current: &Path, anchor: &Path) -> (PathBuf, bool) {
+    let normalized = simple_normalize_path(current);
+
+    let anchor_comps: Vec<_> = anchor.components().collect();
+    let current_comps: Vec<_> = normalized.components().collect();
+
+    let is_within_anchor = current_comps.len() >= anchor_comps.len()
+        && current_comps
+            .iter()
+            .zip(anchor_comps.iter())
+            .all(|(c, a)| component_eq(c, a));
+
+    if is_within_anchor {
+        (normalized, false)
+    } else {
+        let mut common_depth = 0;
+        for (a, c) in anchor_comps.iter().zip(current_comps.iter()) {
+            if component_eq(a, c) {
+                common_depth += 1;
+            } else {
+                break;
+            }
+        }
+        let mut clamped = anchor.to_path_buf();
+        for comp in current_comps.iter().skip(common_depth) {
+            clamped.push(comp);
+        }
+        (clamped, true)
+    }
+}
+
 /// Resolve a symlink chain with anchor clamping for absolute targets.
 ///
 /// This resolver implements virtual filesystem semantics by clamping absolute symlink
@@ -73,31 +145,23 @@ pub(crate) fn strip_root_prefix(path: &Path) -> PathBuf {
 ///
 /// When an absolute symlink target is encountered, it's handled in one of two ways:
 ///
-/// **Case 1: Target already within anchor** (host-style absolute path)
-/// ```text
-/// // Symlink: /tmp/anchor/mylink -> /tmp/anchor/docs/file
-/// // Anchor: /tmp/anchor
-/// // Process: Strip anchor prefix → "docs/file" → Rejoin to anchor
-/// // Result: /tmp/anchor/docs/file ✅ (stays within anchor)
-/// ```
+/// **Case 1: Target already within anchor** (host-style absolute path).
+/// A symlink `/tmp/anchor/mylink` pointing to `/tmp/anchor/docs/file` with
+/// anchor `/tmp/anchor`: the anchor prefix is stripped to `docs/file` and
+/// rejoined to the anchor, yielding `/tmp/anchor/docs/file` — stays within anchor.
 ///
-/// **Case 2: Target outside anchor** (virtual-style absolute path)
-/// ```text
-/// // Symlink: /tmp/anchor/mylink -> /etc/passwd
-/// // Anchor: /tmp/anchor
-/// // Process: Strip root prefix → "etc/passwd" → Join to anchor
-/// // Result: /tmp/anchor/etc/passwd ✅ (clamped to anchor)
-/// ```
+/// **Case 2: Target outside anchor** (virtual-style absolute path).
+/// A symlink `/tmp/anchor/mylink` pointing to `/etc/passwd` with anchor
+/// `/tmp/anchor`: the root prefix is stripped to `etc/passwd` and joined to
+/// the anchor, yielding `/tmp/anchor/etc/passwd` — clamped to anchor.
 ///
 /// Both cases ensure the final path stays within the anchor, implementing true
 /// chroot-like behavior where the anchor is treated as the virtual root (`/`).
 ///
 /// # Example
-/// ```text
-/// // Symlink: /anchor/mylink -> /etc/config
-/// // Result: /anchor/etc/config (clamped to anchor)
-/// let result = resolve_anchored_symlink_chain(&Path::new("/anchor/mylink"), &Path::new("/anchor"))?;
-/// ```
+///
+/// A symlink at `/anchor/mylink` pointing to `/etc/config`, with anchor
+/// `/anchor`, resolves to `/anchor/etc/config` (clamped to anchor).
 #[cfg(feature = "anchored")]
 pub(crate) fn resolve_anchored_symlink_chain(
     symlink_path: &Path,
@@ -114,7 +178,14 @@ pub(crate) fn resolve_anchored_symlink_chain(
     };
 
     loop {
-        // Detect cycles using the textual path (no extra IO)
+        // Detect cycles using the textual path (no extra IO).
+        // Why textual (not case-normalized): on Windows's case-insensitive FS,
+        // a cycle expressed in mixed case (`/Anchor/x` ↔ `/anchor/x`) won't
+        // match here and falls through to the `effective_max_depth` cap below —
+        // same outcome (InvalidInput, "Too many levels of symbolic links"),
+        // just reached via depth exhaustion instead of early detection.
+        // Case-normalizing would require per-component FS queries; the depth
+        // cap is cheap and sufficient.
         if visited.iter().any(|s| s == current.as_os_str()) {
             return Err(error_with_path(
                 io::ErrorKind::InvalidInput,
@@ -151,17 +222,15 @@ pub(crate) fn resolve_anchored_symlink_chain(
                     // AND 8.3 short name vs long name mismatches (e.g., RUNNER~1 vs runneradmin)
                     #[cfg(windows)]
                     let rel_path = {
-                        use std::path::{Component, Prefix};
-
-                        // First, try to canonicalize the target to expand 8.3 short names
-                        // This is needed because junction targets often contain short names
-                        // while the anchor uses long names (or vice versa)
+                        // Expand 8.3 short names in the target so it can be compared with the
+                        // anchor (which uses long names on Windows).  Junction targets often
+                        // carry 8.3 names inherited from the caller's working directory.
                         let target_for_comparison =
                             if let Ok(canonical_target) = std::fs::canonicalize(&target) {
                                 canonical_target
                             } else {
-                                // If canonicalization fails (target doesn't fully exist),
-                                // try to canonicalize the deepest existing prefix
+                                // Target doesn't fully exist: canonicalize the deepest existing
+                                // prefix and re-attach the non-existing suffix verbatim.
                                 let mut check = target.clone();
                                 let mut suffix_parts = Vec::new();
                                 while !check.as_os_str().is_empty() {
@@ -186,46 +255,18 @@ pub(crate) fn resolve_anchored_symlink_chain(
                                 }
                             };
 
-                        // Helper to compare components, treating VerbatimDisk(X) == Disk(X)
-                        let components_equal = |a: &Component, b: &Component| -> bool {
-                            match (a, b) {
-                                (Component::Prefix(ap), Component::Prefix(bp)) => {
-                                    match (ap.kind(), bp.kind()) {
-                                        (Prefix::VerbatimDisk(ad), Prefix::Disk(bd))
-                                        | (Prefix::Disk(ad), Prefix::VerbatimDisk(bd))
-                                        | (Prefix::VerbatimDisk(ad), Prefix::VerbatimDisk(bd))
-                                        | (Prefix::Disk(ad), Prefix::Disk(bd)) => {
-                                            ad.eq_ignore_ascii_case(&bd)
-                                        }
-                                        (Prefix::VerbatimUNC(as1, as2), Prefix::UNC(bs1, bs2))
-                                        | (Prefix::UNC(as1, as2), Prefix::VerbatimUNC(bs1, bs2))
-                                        | (
-                                            Prefix::VerbatimUNC(as1, as2),
-                                            Prefix::VerbatimUNC(bs1, bs2),
-                                        )
-                                        | (Prefix::UNC(as1, as2), Prefix::UNC(bs1, bs2)) => {
-                                            as1.eq_ignore_ascii_case(bs1)
-                                                && as2.eq_ignore_ascii_case(bs2)
-                                        }
-                                        _ => ap == bp,
-                                    }
-                                }
-                                _ => a == b,
-                            }
-                        };
-
                         let anchor_comps: Vec<_> = anchor.components().collect();
                         let target_comps: Vec<_> = target_for_comparison.components().collect();
 
-                        // Check if target starts with anchor (using component-aware comparison)
+                        // Component-aware prefix match handles `\\?\C:` vs `C:` and UNC
+                        // verbatim-vs-legacy equivalence (see `component_eq`).
                         let is_within_anchor = target_comps.len() >= anchor_comps.len()
                             && target_comps
                                 .iter()
                                 .zip(anchor_comps.iter())
-                                .all(|(t, a)| components_equal(t, a));
+                                .all(|(t, a)| component_eq(t, a));
 
                         if is_within_anchor {
-                            // Build relative path from remaining components
                             let mut rel = std::path::PathBuf::new();
                             for comp in target_comps.iter().skip(anchor_comps.len()) {
                                 rel.push(comp);
@@ -239,83 +280,31 @@ pub(crate) fn resolve_anchored_symlink_chain(
                     #[cfg(not(windows))]
                     let rel_path = target.strip_prefix(anchor).ok().map(|p| p.to_path_buf());
 
-                    if let Some(rel) = rel_path {
+                    let tentative = if let Some(rel) = rel_path {
                         // Target is already within anchor: rejoin to anchor to normalize
-                        current = anchor.join(rel);
+                        anchor.join(rel)
                     } else {
                         // Target is outside anchor: strip root and clamp to anchor
                         // /etc/passwd -> anchor/etc/passwd
                         let stripped = strip_root_prefix(&target);
-                        current = anchor.join(stripped);
-                    }
+                        anchor.join(stripped)
+                    };
+                    // SECURITY: Normalize + clamp. The raw symlink target (and, in some
+                    // Windows fallback paths, the computed `rel`) may contain literal `..`
+                    // segments. Without this step, the returned path would still textually
+                    // start with the anchor but escape when the OS resolves it.
+                    let (clamped, _was_clamped) = normalize_and_clamp_to_anchor(&tentative, anchor);
+                    current = clamped;
                 } else {
                     // Relative symlink: resolve from parent, then clamp to anchor
                     // Virtual filesystem semantics: relative symlinks are resolved as if
                     // the anchor is the root - they cannot escape the anchor boundary
                     let parent = current.parent();
                     if let Some(p) = parent {
-                        current = simple_normalize_path(&p.join(target));
-
-                        // CLAMP: Ensure relative symlink resolution stays within anchor
-                        // If the resolved path escapes the anchor, clamp it back using common ancestor logic
-                        //
-                        // Use component-based comparison to handle Windows prefix format differences
-                        // (\\?\ vs normal paths) - components() normalizes these away
-                        let anchor_comps: Vec<_> = anchor.components().collect();
-                        let current_comps: Vec<_> = current.components().collect();
-
-                        // Helper to compare components, treating VerbatimDisk(X) == Disk(X)
-                        #[cfg(windows)]
-                        let components_equal = |a: &std::path::Component,
-                                                b: &std::path::Component|
-                         -> bool {
-                            use std::path::{Component, Prefix};
-                            match (a, b) {
-                                (Component::Prefix(ap), Component::Prefix(bp)) => {
-                                    // Treat VerbatimDisk and Disk as equivalent if same drive letter
-                                    match (ap.kind(), bp.kind()) {
-                                        (Prefix::VerbatimDisk(ad), Prefix::Disk(bd))
-                                        | (Prefix::Disk(ad), Prefix::VerbatimDisk(bd))
-                                        | (Prefix::VerbatimDisk(ad), Prefix::VerbatimDisk(bd))
-                                        | (Prefix::Disk(ad), Prefix::Disk(bd)) => ad == bd,
-                                        _ => ap == bp, // Other prefix types must match exactly
-                                    }
-                                }
-                                _ => a == b, // Non-prefix components must match exactly
-                            }
-                        };
-                        #[cfg(not(windows))]
-                        let components_equal =
-                            |a: &std::path::Component, b: &std::path::Component| a == b;
-
-                        // Check if current path is within anchor by comparing components
-                        let is_within_anchor = current_comps.len() >= anchor_comps.len()
-                            && current_comps
-                                .iter()
-                                .zip(anchor_comps.iter())
-                                .all(|(c, a)| components_equal(c, a));
-
-                        let _was_clamped = if !is_within_anchor {
-                            // Find longest common prefix by comparing components
-                            let mut common_depth = 0;
-                            for (a, c) in anchor_comps.iter().zip(current_comps.iter()) {
-                                if components_equal(a, c) {
-                                    common_depth += 1;
-                                } else {
-                                    break;
-                                }
-                            }
-
-                            // Build clamped path: anchor + (current components after common prefix)
-                            let mut clamped = anchor.to_path_buf();
-                            for comp in current_comps.iter().skip(common_depth) {
-                                clamped.push(comp);
-                            }
-                            current = clamped;
-                            true // Mark that we clamped
-                        } else {
-                            false // No clamping needed
-                        };
+                        let joined = p.join(target);
+                        let (clamped, _was_clamped) =
+                            normalize_and_clamp_to_anchor(&joined, anchor);
+                        current = clamped;
 
                         // FIX: Re-canonicalize on Windows to ensure:
                         // 1. Prefix format consistency (\\?\ vs regular paths)
@@ -391,7 +380,9 @@ pub(crate) fn resolve_simple_symlink_chain(symlink_path: &Path) -> io::Result<Pa
     };
 
     loop {
-        // Detect cycles using the textual path (no extra IO)
+        // Detect cycles using the textual path (no extra IO).
+        // See `resolve_anchored_symlink_chain` for the rationale behind using
+        // textual (not case-normalized) comparison here.
         if visited.iter().any(|s| s == current.as_os_str()) {
             return Err(error_with_path(
                 io::ErrorKind::InvalidInput,

--- a/src/tests/anchored_security/windows_symlink.rs
+++ b/src/tests/anchored_security/windows_symlink.rs
@@ -55,6 +55,54 @@ fn anchored_relative_symlink_keeps_clamp_windows() -> std::io::Result<()> {
     Ok(())
 }
 
+/// Sibling of `anchored_relative_symlink_keeps_clamp_windows` that covers the
+/// DIFFERENT code path: an absolute link target already inside the anchor
+/// (strip-anchor-prefix + rejoin branch of `resolve_anchored_symlink_chain`).
+/// Uses a directory symlink when permitted and falls back to a junction
+/// (`junction-verbatim`) on error 1314, so non-admin / non-Developer-Mode
+/// sessions still exercise the floor-aware `..` pop in `anchored.rs`.
+/// Both code paths must produce `<anchor>/opt/subdir/hello/world`.
+#[test]
+fn anchored_symlink_or_junction_keeps_clamp_windows() -> std::io::Result<()> {
+    use std::io;
+    use std::os::windows::fs::symlink_dir;
+
+    let td = TempDir::new()?;
+    let anchor = td.path().join("home").join("jail");
+    fs::create_dir_all(&anchor)?;
+    fs::create_dir_all(anchor.join("opt").join("subdir").join("special"))?;
+    fs::create_dir_all(
+        anchor
+            .join("opt")
+            .join("subdir")
+            .join("hello")
+            .join("world"),
+    )?;
+
+    let base = soft_canonicalize(&anchor)?;
+    let link = base.join("special");
+    let absolute_target = base.join("opt").join("subdir").join("special");
+
+    // Try a symlink first; fall back to a junction if Windows denies symlink
+    // creation (error 1314). Junctions need an absolute target, so we use one
+    // here for both variants — it keeps the setup uniform.
+    match symlink_dir(&absolute_target, &link) {
+        Ok(_) => {}
+        Err(e) if e.kind() == io::ErrorKind::PermissionDenied || e.raw_os_error() == Some(1314) => {
+            junction_verbatim::create(&absolute_target, &link)?;
+        }
+        Err(e) => return Err(e),
+    }
+
+    // `special` resolves via the link to `<base>/opt/subdir/special`; the
+    // following `..` must pop to `<base>/opt/subdir`; then `hello/world` is
+    // appended. The bug would leak `special\hello\world` into the tail.
+    let out = anchored_canonicalize(&base, r"special\..\hello\world")?;
+    let expected = base.join("opt").join("subdir").join("hello").join("world");
+    assert_eq!(out, expected);
+    Ok(())
+}
+
 #[test]
 fn anchored_absolute_symlink_is_clamped_windows() -> std::io::Result<()> {
     use std::io;

--- a/src/tests/security_audit/unicode.rs
+++ b/src/tests/security_audit/unicode.rs
@@ -98,6 +98,50 @@ fn test_null_byte_injection_extended() {
     }
 }
 
+/// WHITE-BOX: defense-in-depth — `reject_nul_bytes` must detect a NUL embedded
+/// in a PathBuf that could hypothetically come from a malicious symlink target
+/// (or a crafted FUSE / filesystem image) and bypass the Stage 0 input check.
+///
+/// Standard `symlink(2)` / `CreateSymbolicLink` reject NULs in targets at
+/// creation time, so we cannot synthesize this via normal FS APIs in CI.
+/// This test verifies the primitive is sound so the post-resolve call-site
+/// in `soft_canonicalize` / `anchored_canonicalize` will reliably catch any
+/// NUL that slips through.
+#[test]
+fn test_reject_nul_bytes_detects_nul_in_constructed_pathbuf() {
+    use crate::IoErrorPathExt;
+    use std::path::PathBuf;
+
+    #[cfg(unix)]
+    let nul_path: PathBuf = {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+        PathBuf::from(OsString::from_vec(b"/tmp/resolved\0/suffix".to_vec()))
+    };
+    #[cfg(windows)]
+    let nul_path: PathBuf = {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+        let units: Vec<u16> = "C:\\resolved"
+            .encode_utf16()
+            .chain(std::iter::once(0u16))
+            .chain("\\suffix".encode_utf16())
+            .collect();
+        PathBuf::from(OsString::from_wide(&units))
+    };
+    #[cfg(not(any(unix, windows)))]
+    let nul_path = PathBuf::from("resolved\0suffix");
+
+    let err =
+        crate::reject_nul_bytes(&nul_path).expect_err("NUL-containing PathBuf must be rejected");
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(err.soft_canon_detail(), Some("path contains null byte"));
+
+    // And confirm a NUL-free PathBuf is NOT rejected (no false positives).
+    let clean = PathBuf::from("safe/path/without/nul");
+    assert!(crate::reject_nul_bytes(&clean).is_ok());
+}
+
 #[test]
 fn test_null_byte_error_consistency() {
     // Test that soft_canonicalize behaves consistently with std::fs::canonicalize

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -5,18 +5,34 @@ use crate::error::error_with_path;
 
 #[inline]
 pub(crate) fn is_incomplete_unc(p: &Path) -> bool {
-    // Detect \\server or \\server\\ (no share). Exclude verbatim and device namespaces.
+    // Detect \\server, //server, or any two-separator prefix with no share.
+    // Why: forward-slash UNCs are not classified by Rust's Prefix parser, so
+    // `//server` would otherwise slip past this guard and be reinterpreted by
+    // stdlib as relative-to-cwd (e.g., `//secret` → `C:\secret`), surprising
+    // callers who passed what they thought was a UNC path.
+    // Exclude verbatim (`\\?\`, `//?/`) and device (`\\.\`, `//./`) namespaces.
     let raw = p.as_os_str().to_string_lossy();
-    if raw.starts_with("\\\\") && !raw.starts_with("\\\\?\\") && !raw.starts_with("\\\\.\\") {
-        let mut parts = raw
-            .trim_start_matches(['\\', '/'])
-            .split(['\\', '/'])
-            .filter(|s| !s.is_empty());
-        let server = parts.next();
-        let share = parts.next();
-        return server.is_some() && share.is_none();
+    let starts_with_two_seps = raw.starts_with("\\\\")
+        || raw.starts_with("//")
+        || raw.starts_with("\\/")
+        || raw.starts_with("/\\");
+    if !starts_with_two_seps {
+        return false;
     }
-    false
+    // Check for verbatim/device namespaces using either slash variant at positions 2-3
+    let bytes = raw.as_bytes();
+    let is_verbatim_or_device =
+        bytes.len() >= 4 && matches!(bytes[2], b'?' | b'.') && matches!(bytes[3], b'\\' | b'/');
+    if is_verbatim_or_device {
+        return false;
+    }
+    let mut parts = raw
+        .trim_start_matches(['\\', '/'])
+        .split(['\\', '/'])
+        .filter(|s| !s.is_empty());
+    let server = parts.next();
+    let share = parts.next();
+    server.is_some() && share.is_none()
 }
 
 pub(crate) fn validate_windows_ads_layout(p: &Path) -> io::Result<()> {

--- a/tests/anchored_absolute_symlink_dotdot_escape.rs
+++ b/tests/anchored_absolute_symlink_dotdot_escape.rs
@@ -49,7 +49,7 @@ fn absolute_symlink_target_with_leading_dotdot_must_not_escape_anchor() {
     fs::create_dir(&anchor).unwrap();
 
     let secret_path = tmp.path().join("outside_secret");
-    fs::write(&secret_path, b"CONFIDENTIAL").unwrap();
+    fs::write(secret_path, b"CONFIDENTIAL").unwrap();
 
     // Raw absolute symlink target "/../outside_secret":
     //   - is_absolute() == true (leading "/")
@@ -58,7 +58,7 @@ fn absolute_symlink_target_with_leading_dotdot_must_not_escape_anchor() {
     //     producing "<anchor>/../outside_secret" — which the kernel will resolve
     //     to "<tmp>/outside_secret" and READ THE SECRET.
     let link = anchor.join("link");
-    symlink("/../outside_secret", &link).unwrap();
+    symlink("/../outside_secret", link).unwrap();
 
     let clamped = anchored_canonicalize(&anchor, "link")
         .expect("anchored_canonicalize should succeed on a valid symlink");
@@ -105,7 +105,7 @@ fn absolute_symlink_target_with_interior_dotdot_must_not_escape_anchor() {
     fs::create_dir(&anchor).unwrap();
 
     let secret_path = tmp.path().join("outside_secret2");
-    fs::write(&secret_path, b"TOPSECRET").unwrap();
+    fs::write(secret_path, b"TOPSECRET").unwrap();
 
     // Target "/foo/../../outside_secret2":
     //   - strip_root_prefix → "foo/../../outside_secret2"
@@ -118,7 +118,7 @@ fn absolute_symlink_target_with_interior_dotdot_must_not_escape_anchor() {
     fs::create_dir(anchor.join("foo")).unwrap();
 
     let link = anchor.join("link");
-    symlink("/foo/../../outside_secret2", &link).unwrap();
+    symlink("/foo/../../outside_secret2", link).unwrap();
 
     let clamped =
         anchored_canonicalize(&anchor, "link").expect("anchored_canonicalize should succeed");

--- a/tests/anchored_absolute_symlink_dotdot_escape.rs
+++ b/tests/anchored_absolute_symlink_dotdot_escape.rs
@@ -63,7 +63,23 @@ fn absolute_symlink_target_with_leading_dotdot_must_not_escape_anchor() {
     let clamped = anchored_canonicalize(&anchor, "link")
         .expect("anchored_canonicalize should succeed on a valid symlink");
 
-    // --- Contract 1: output must not contain ".." components ---
+    // --- Contract 1 (primary): exact clamped path ---
+    // The raw target "/../outside_secret" has its leading slash stripped to
+    // "../outside_secret", then the ".." is popped with an empty stack (clamp
+    // to anchor floor), leaving just "outside_secret" to be joined onto the
+    // canonicalized anchor. Asserting the full expected PathBuf pins the
+    // clamp contract directly, without relying on the OS resolving the result.
+    let expected = soft_canonicalize(&anchor).unwrap().join("outside_secret");
+    assert_eq!(
+        clamped, expected,
+        "anchored_canonicalize must clamp absolute '..'-bearing symlink target \
+         to anchor floor; got {clamped:?}, expected {expected:?}"
+    );
+
+    // --- Contract 2 (invariant): output must not contain ".." components ---
+    // Subsumed by Contract 1 for this exact input, but keeps a fast local
+    // invariant check that any future change to the expected-path shape
+    // cannot silently re-introduce literal ".." into the output.
     let leaked_dotdot = clamped
         .components()
         .any(|c| matches!(c, Component::ParentDir));
@@ -72,27 +88,6 @@ fn absolute_symlink_target_with_leading_dotdot_must_not_escape_anchor() {
         "anchored_canonicalize leaked '..' into output; anchor escape is possible \
          when the caller consumes this path: {clamped:?}"
     );
-
-    // --- Contract 2: the resolved path must stay within the canonical anchor ---
-    // Use fs::canonicalize to see what the OS *actually* resolves the returned
-    // path to. If that escapes the canonical anchor, the clamping contract is
-    // broken regardless of whether the textual path starts_with() the anchor.
-    let canonical_anchor = soft_canonicalize(&anchor).unwrap();
-    if let Ok(os_resolved) = fs::canonicalize(&clamped) {
-        assert!(
-            os_resolved.starts_with(&canonical_anchor),
-            "anchored_canonicalize returned a path that OS-resolves outside the anchor: \
-             returned={clamped:?}, os_resolved={os_resolved:?}, anchor={canonical_anchor:?}"
-        );
-    }
-
-    // --- Contract 3: reading the returned path must NOT return the outside secret ---
-    if let Ok(bytes) = fs::read(&clamped) {
-        assert_ne!(
-            bytes, b"CONFIDENTIAL",
-            "anchor ESCAPE: clamped result reads the outside-anchor secret: {clamped:?}"
-        );
-    }
 }
 
 #[test]
@@ -123,6 +118,21 @@ fn absolute_symlink_target_with_interior_dotdot_must_not_escape_anchor() {
     let clamped =
         anchored_canonicalize(&anchor, "link").expect("anchored_canonicalize should succeed");
 
+    // --- Contract 1 (primary): exact clamped path ---
+    // Strip root → "foo/../../outside_secret2". Normalize with clamp:
+    //   push "foo"            stack: [foo]
+    //   ".."  pop             stack: []
+    //   ".."  clamp (empty)   stack: []
+    //   push "outside_secret2" stack: [outside_secret2]
+    // Final: <canonical_anchor>/outside_secret2.
+    let expected = soft_canonicalize(&anchor).unwrap().join("outside_secret2");
+    assert_eq!(
+        clamped, expected,
+        "anchored_canonicalize must clamp interior-'..'-bearing symlink target \
+         to anchor floor; got {clamped:?}, expected {expected:?}"
+    );
+
+    // --- Contract 2 (invariant): output must not contain ".." components ---
     let leaked_dotdot = clamped
         .components()
         .any(|c| matches!(c, Component::ParentDir));
@@ -130,13 +140,4 @@ fn absolute_symlink_target_with_interior_dotdot_must_not_escape_anchor() {
         !leaked_dotdot,
         "anchored_canonicalize leaked '..' into output (interior ..): {clamped:?}"
     );
-
-    let canonical_anchor = soft_canonicalize(&anchor).unwrap();
-    if let Ok(os_resolved) = fs::canonicalize(&clamped) {
-        assert!(
-            os_resolved.starts_with(&canonical_anchor),
-            "interior-dotdot anchor escape: returned={clamped:?}, \
-             os_resolved={os_resolved:?}, anchor={canonical_anchor:?}"
-        );
-    }
 }

--- a/tests/anchored_absolute_symlink_dotdot_escape.rs
+++ b/tests/anchored_absolute_symlink_dotdot_escape.rs
@@ -1,0 +1,142 @@
+//! Security regression: `anchored_canonicalize` must not leak `..` components
+//! into its output when an absolute symlink target contains `..` segments.
+//!
+//! # Bug
+//!
+//! In `src/symlink.rs::resolve_anchored_symlink_chain`, the branch that handles
+//! absolute symlink targets outside the anchor strips only the leading root
+//! separator from the RAW (un-normalized) target and joins the remainder to
+//! the anchor. Unlike the relative-symlink branch (which runs
+//! `simple_normalize_path` and clamps via common-ancestor), the absolute branch
+//! never normalizes `..` in the target. If the symlink points at an absolute
+//! path whose components include `..` (legal as symlink text, collapsed at
+//! root by the kernel), the resulting `anchor.join(..)` path contains literal
+//! `..` that escape the anchor when resolved by the OS.
+//!
+//! # Contract violation
+//!
+//! `anchored_canonicalize` documents virtual-filesystem / chroot-like semantics:
+//!   > All absolute symlink targets are clamped to the anchor.
+//!   > Safe: always stays within workspace_root, even if symlink points outside.
+//!
+//! A returned path that contains `..` is NOT clamped — any caller that uses it
+//! (File::open, fs::read, fs::canonicalize, etc.) has the `..` resolved by the
+//! OS and escapes the anchor.
+//!
+//! # Reproduction (Unix)
+//!
+//! Create a symlink inside the anchor whose raw absolute target begins with
+//! `..` after the leading slash, e.g. `/../sibling/file`. `anchored_canonicalize`
+//! returns `<anchor>/../sibling/file`, which reads the sibling file when opened.
+
+#![cfg(all(unix, feature = "anchored"))]
+
+use soft_canonicalize::{anchored_canonicalize, soft_canonicalize};
+use std::fs;
+use std::os::unix::fs::symlink;
+use std::path::Component;
+use tempfile::TempDir;
+
+#[test]
+fn absolute_symlink_target_with_leading_dotdot_must_not_escape_anchor() {
+    let tmp = TempDir::new().unwrap();
+
+    // Layout:
+    //   <tmp>/sandbox           (anchor)
+    //   <tmp>/sandbox/link      (symlink we create)
+    //   <tmp>/outside_secret    (sibling of the anchor — "attacker loot")
+    let anchor = tmp.path().join("sandbox");
+    fs::create_dir(&anchor).unwrap();
+
+    let secret_path = tmp.path().join("outside_secret");
+    fs::write(&secret_path, b"CONFIDENTIAL").unwrap();
+
+    // Raw absolute symlink target "/../outside_secret":
+    //   - is_absolute() == true (leading "/")
+    //   - kernel resolves to "/outside_secret" when accessed directly
+    //   - but soft-canonicalize only strips the leading "/" and rejoins to anchor,
+    //     producing "<anchor>/../outside_secret" — which the kernel will resolve
+    //     to "<tmp>/outside_secret" and READ THE SECRET.
+    let link = anchor.join("link");
+    symlink("/../outside_secret", &link).unwrap();
+
+    let clamped = anchored_canonicalize(&anchor, "link")
+        .expect("anchored_canonicalize should succeed on a valid symlink");
+
+    // --- Contract 1: output must not contain ".." components ---
+    let leaked_dotdot = clamped
+        .components()
+        .any(|c| matches!(c, Component::ParentDir));
+    assert!(
+        !leaked_dotdot,
+        "anchored_canonicalize leaked '..' into output; anchor escape is possible \
+         when the caller consumes this path: {clamped:?}"
+    );
+
+    // --- Contract 2: the resolved path must stay within the canonical anchor ---
+    // Use fs::canonicalize to see what the OS *actually* resolves the returned
+    // path to. If that escapes the canonical anchor, the clamping contract is
+    // broken regardless of whether the textual path starts_with() the anchor.
+    let canonical_anchor = soft_canonicalize(&anchor).unwrap();
+    if let Ok(os_resolved) = fs::canonicalize(&clamped) {
+        assert!(
+            os_resolved.starts_with(&canonical_anchor),
+            "anchored_canonicalize returned a path that OS-resolves outside the anchor: \
+             returned={clamped:?}, os_resolved={os_resolved:?}, anchor={canonical_anchor:?}"
+        );
+    }
+
+    // --- Contract 3: reading the returned path must NOT return the outside secret ---
+    if let Ok(bytes) = fs::read(&clamped) {
+        assert_ne!(
+            bytes, b"CONFIDENTIAL",
+            "anchor ESCAPE: clamped result reads the outside-anchor secret: {clamped:?}"
+        );
+    }
+}
+
+#[test]
+fn absolute_symlink_target_with_interior_dotdot_must_not_escape_anchor() {
+    // Variant: ".." appears after some path components, not just at the start.
+    // Same class of bug — the absolute-symlink branch never normalizes the target.
+    let tmp = TempDir::new().unwrap();
+
+    let anchor = tmp.path().join("sandbox");
+    fs::create_dir(&anchor).unwrap();
+
+    let secret_path = tmp.path().join("outside_secret2");
+    fs::write(&secret_path, b"TOPSECRET").unwrap();
+
+    // Target "/foo/../../outside_secret2":
+    //   - strip_root_prefix → "foo/../../outside_secret2"
+    //   - anchor.join(...) → "<anchor>/foo/../../outside_secret2"
+    //   - OS resolves: <anchor>/foo doesn't exist, but kernel will still apply
+    //     ".." relative to <anchor>, reaching <anchor>/.. == <tmp>, then
+    //     <tmp>/../outside_secret2 = <tmp_parent>/outside_secret2 — NOT what we want
+    //     for escape UNLESS <anchor>/foo exists. Create it so the ".." collapses
+    //     cleanly and lands inside <tmp>.
+    fs::create_dir(anchor.join("foo")).unwrap();
+
+    let link = anchor.join("link");
+    symlink("/foo/../../outside_secret2", &link).unwrap();
+
+    let clamped =
+        anchored_canonicalize(&anchor, "link").expect("anchored_canonicalize should succeed");
+
+    let leaked_dotdot = clamped
+        .components()
+        .any(|c| matches!(c, Component::ParentDir));
+    assert!(
+        !leaked_dotdot,
+        "anchored_canonicalize leaked '..' into output (interior ..): {clamped:?}"
+    );
+
+    let canonical_anchor = soft_canonicalize(&anchor).unwrap();
+    if let Ok(os_resolved) = fs::canonicalize(&clamped) {
+        assert!(
+            os_resolved.starts_with(&canonical_anchor),
+            "interior-dotdot anchor escape: returned={clamped:?}, \
+             os_resolved={os_resolved:?}, anchor={canonical_anchor:?}"
+        );
+    }
+}

--- a/tests/regression_incomplete_unc_forward_slash.rs
+++ b/tests/regression_incomplete_unc_forward_slash.rs
@@ -1,0 +1,52 @@
+//! Regression test: `//server` (forward-slash incomplete UNC) must be rejected
+//! with our path-aware `InvalidInput` error, identical to the backslash form.
+//!
+//! Before the fix, `is_incomplete_unc` only matched paths starting with `\\`.
+//! A forward-slash form like `//server` slipped past the guard and relied on
+//! stdlib's generic error. We want defense-in-depth that does not depend on
+//! stdlib's treatment of forward-slash UNCs.
+
+#![cfg(windows)]
+
+use soft_canonicalize::{soft_canonicalize, IoErrorPathExt};
+use std::io;
+
+#[test]
+fn forward_slash_incomplete_unc_rejected_with_our_detail() {
+    let err =
+        soft_canonicalize("//server").expect_err("forward-slash incomplete UNC must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(
+        err.soft_canon_detail(),
+        Some("invalid UNC path: missing share"),
+        "expected our path-aware detail, got: {:?}",
+        err.soft_canon_detail()
+    );
+}
+
+#[test]
+fn forward_slash_incomplete_unc_matches_backslash_form() {
+    let backslash_err =
+        soft_canonicalize(r"\\server").expect_err("backslash incomplete UNC must be rejected");
+    let forward_err =
+        soft_canonicalize("//server").expect_err("forward-slash incomplete UNC must be rejected");
+    assert_eq!(backslash_err.kind(), forward_err.kind());
+    assert_eq!(
+        backslash_err.soft_canon_detail(),
+        forward_err.soft_canon_detail(),
+        "forward-slash and backslash forms must produce identical details"
+    );
+}
+
+#[cfg(feature = "anchored")]
+#[test]
+fn anchored_forward_slash_incomplete_unc_rejected() {
+    use soft_canonicalize::anchored_canonicalize;
+    let err = anchored_canonicalize("//server", "foo")
+        .expect_err("forward-slash incomplete UNC anchor must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(
+        err.soft_canon_detail(),
+        Some("invalid UNC path: missing share"),
+    );
+}

--- a/tests/regression_incomplete_unc_forward_slash.rs
+++ b/tests/regression_incomplete_unc_forward_slash.rs
@@ -38,6 +38,24 @@ fn forward_slash_incomplete_unc_matches_backslash_form() {
     );
 }
 
+#[test]
+fn mixed_separator_incomplete_unc_rejected() {
+    // `is_incomplete_unc` accepts all four two-separator prefix combinations:
+    // `\\`, `//`, `\/`, `/\`. The backslash and forward-slash pure forms are
+    // covered above; these two pin the mixed-separator variants so a future
+    // refactor of the prefix-match cannot silently drop them.
+    for form in [r"\/server", r"/\server"] {
+        let err =
+            soft_canonicalize(form).expect_err("mixed-separator incomplete UNC must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput, "form={form:?}");
+        assert_eq!(
+            err.soft_canon_detail(),
+            Some("invalid UNC path: missing share"),
+            "form={form:?}",
+        );
+    }
+}
+
 #[cfg(feature = "anchored")]
 #[test]
 fn anchored_forward_slash_incomplete_unc_rejected() {
@@ -49,4 +67,42 @@ fn anchored_forward_slash_incomplete_unc_rejected() {
         err.soft_canon_detail(),
         Some("invalid UNC path: missing share"),
     );
+}
+
+/// Contract documentation: `anchored_canonicalize` strips root/prefix markers
+/// from the INPUT per spec (virtual-filesystem semantics treat all absolute
+/// inputs as rooted under the anchor). `is_incomplete_unc` is only applied to
+/// the ANCHOR — a malformed anchor has no meaningful virtual root — so an
+/// incomplete UNC like `\\server` supplied as INPUT is NOT rejected.
+///
+/// Observed contract: Rust's `Path` parser treats `\\server` (and the
+/// slash-variant siblings `//server`, `\/server`, `/\server`) as
+/// `[RootDir, Normal("server")]` — the two leading separators are stripped
+/// as root, and `server` is pushed as a Normal component. The result is
+/// therefore `<anchor>/server`, not just `<anchor>`.
+///
+/// This test pins that behavior so a future reader does not mistake the
+/// absence of rejection for a bug, and so a future refactor of the input
+/// stripping cannot silently drift to a different outcome.
+#[cfg(feature = "anchored")]
+#[test]
+fn anchored_incomplete_unc_as_input_is_stripped_not_rejected() {
+    use soft_canonicalize::{anchored_canonicalize, soft_canonicalize};
+    use tempfile::TempDir;
+
+    let td = TempDir::new().expect("tempdir");
+    let anchor = td.path().join("a");
+    std::fs::create_dir(&anchor).expect("create anchor");
+    let base = soft_canonicalize(&anchor).expect("canonicalize anchor");
+    let expected = base.join("server");
+
+    for input in [r"\\server", r"//server", r"\/server", r"/\server"] {
+        let out = anchored_canonicalize(&base, input)
+            .unwrap_or_else(|e| panic!("input {input:?} must NOT error: {e}"));
+        assert_eq!(
+            out, expected,
+            "incomplete-UNC input {input:?} must strip leading separators \
+             and land at <anchor>/server"
+        );
+    }
 }

--- a/tests/regression_nul_byte_error_detail.rs
+++ b/tests/regression_nul_byte_error_detail.rs
@@ -1,0 +1,96 @@
+//! Regression test: a path containing an embedded NUL byte must be rejected
+//! by *our* `reject_nul_bytes` check (not by stdlib's canonicalize), so callers
+//! can reliably identify the failure via `soft_canon_detail()`.
+//!
+//! Before the fix, `reject_nul_bytes` ran in Stage 3.1 — after both
+//! `fs_canonicalize` fast-paths. Stdlib rejected the NUL first with a generic
+//! `InvalidInput`, our detail was never attached, and callers had no stable
+//! way to distinguish "NUL byte" from other `InvalidInput` causes.
+//!
+//! After the fix, the NUL check runs in Stage 0 (before any FS contact), so
+//! our detail string is always observable.
+
+use soft_canonicalize::{soft_canonicalize, IoErrorPathExt};
+use std::ffi::OsString;
+use std::io;
+use std::path::PathBuf;
+
+fn path_with_embedded_nul() -> PathBuf {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        // `/tmp/foo\0bar` — absolute to skip cwd join; contains an embedded NUL.
+        PathBuf::from(OsString::from_vec(b"/tmp/foo\0bar".to_vec()))
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStringExt;
+        // `C:\foo\0bar` as UTF-16 code units with an embedded NUL unit.
+        let units: Vec<u16> = "C:\\foo"
+            .encode_utf16()
+            .chain(std::iter::once(0u16))
+            .chain("bar".encode_utf16())
+            .collect();
+        PathBuf::from(OsString::from_wide(&units))
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        PathBuf::from("foo\0bar")
+    }
+}
+
+#[test]
+fn embedded_nul_rejected_with_our_detail() {
+    let path = path_with_embedded_nul();
+    let err = soft_canonicalize(path).expect_err("embedded NUL must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(
+        err.soft_canon_detail(),
+        Some("path contains null byte"),
+        "expected our path-aware detail, got: {:?}",
+        err.soft_canon_detail()
+    );
+}
+
+#[test]
+fn embedded_nul_error_carries_offending_path() {
+    let path = path_with_embedded_nul();
+    let err = soft_canonicalize(&path).expect_err("embedded NUL must be rejected");
+    assert_eq!(
+        err.offending_path(),
+        Some(path.as_path()),
+        "error must carry the offending path for diagnostics"
+    );
+}
+
+#[cfg(feature = "anchored")]
+#[test]
+fn anchored_embedded_nul_in_input_rejected_with_our_detail() {
+    use soft_canonicalize::anchored_canonicalize;
+    let anchor = std::env::temp_dir();
+    let input = {
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+            PathBuf::from(OsString::from_vec(b"foo\0bar".to_vec()))
+        }
+        #[cfg(windows)]
+        {
+            use std::os::windows::ffi::OsStringExt;
+            let units: Vec<u16> = "foo"
+                .encode_utf16()
+                .chain(std::iter::once(0u16))
+                .chain("bar".encode_utf16())
+                .collect();
+            PathBuf::from(OsString::from_wide(&units))
+        }
+        #[cfg(not(any(unix, windows)))]
+        {
+            PathBuf::from("foo\0bar")
+        }
+    };
+    let err =
+        anchored_canonicalize(anchor, input).expect_err("embedded NUL in input must be rejected");
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(err.soft_canon_detail(), Some("path contains null byte"));
+}

--- a/tests/windows_8_3_unit_tests.rs
+++ b/tests/windows_8_3_unit_tests.rs
@@ -89,8 +89,7 @@ mod unit_tests {
             (r"C:\файл~1", false),     // Non-ASCII before ~
         ];
 
-        for (path_str, should_look_like_8_3) in valid_8_3.into_iter().chain(invalid_8_3.into_iter())
-        {
+        for (path_str, should_look_like_8_3) in valid_8_3.into_iter().chain(invalid_8_3) {
             let result = soft_canonicalize(path_str);
             if let Ok(path) = result {
                 println!(


### PR DESCRIPTION
# Release v0.5.6: Windows prefix-mismatch fixes and NUL/UNC security hardening

## Summary

Security hardening and Windows correctness fixes focused on the `anchored_canonicalize` clamp logic and NUL-byte / UNC input validation.

Three bug fixes with release-gating severity:

1. **Windows `anchored_canonicalize` escape** via absolute symlink targets beginning with `..`. Clamp logic unified in one helper (`normalize_and_clamp_to_anchor`) so every anchor call-site uses the same `..`-normalizing, common-prefix-clamping path.
2. **Windows `simple_normalize_path` dropped `VerbatimDisk` prefix** when rebuilding `\\?\C:\…` paths. `Path::starts_with` treats `Disk` vs `VerbatimDisk` as distinct, so anchored clamp checks against a verbatim floor silently failed.
3. **Windows anchored `..` pop silently skipped** on `Disk` vs `VerbatimDisk` mismatch (the consumer side of the same prefix bug as #2). Now uses component-wise `is_strictly_below` built on `component_eq`, which equates the two prefix forms.

Two supporting hardening changes:

4. **NUL-byte detection now always path-aware**: `reject_nul_bytes` runs at Stage 0 of `soft_canonicalize` and again on the output, so `IoErrorPathExt::soft_canon_detail()` consistently returns `"path contains null byte"` instead of stdlib's generic `InvalidInput` — even when a NUL enters via symlink-target resolution.
5. **Forward-slash UNC rejection**: `is_incomplete_unc` now detects `//server` and mixed-separator UNC forms, while still excluding verbatim (`\\?\`) and device (`\\.\`) namespaces for both separator kinds.

Plus an upstream dependency bump that ships a namespace-boundary bypass fix:

6. **`proc-canonicalize` 0.1.2 → 0.1.3**: pulls in the upstream fix for `/proc/<PID>/../<PID>/root` paths that lexically normalize to `/proc/<PID>/root` but previously evaded detection. The scanner now lexically normalizes before boundary detection. Includes a heap-allocation removal in the indirect-symlink scanner.

## Why now

All three Windows bugs were silent: the buggy branch returned a wrong path instead of erroring, so callers had no way to notice. The `anchored_canonicalize` path is the crate's primary sandboxing API — any silent clamp skip is a security-relevant correctness bug, not a stylistic one. The `proc-canonicalize` upstream fix extends the same guarantee on Linux.

## What changed

### Security

- Moved `reject_nul_bytes` to Stage 0 of `soft_canonicalize` + final output pass (`src/lib.rs`).
- Fixed `anchored_canonicalize` absolute-`..`-target escape by extracting `normalize_and_clamp_to_anchor` (`src/symlink.rs`, `src/anchored.rs`).
- Added Windows-aware `component_eq` that equates `VerbatimDisk`/`Disk` and `VerbatimUNC`/`UNC` (case-insensitive drive letters + UNC server/share).
- `is_incomplete_unc` extended to forward-slash and mixed-separator UNC forms (`src/windows.rs`).
- `proc-canonicalize` 0.1.2 → 0.1.3 (`Cargo.toml`).

### Fixed (Windows)

- `simple_normalize_path` now preserves `VerbatimDisk` by constructing the verbatim path as a single `PathBuf::from(format!(r"\\?\{drive}\"))` instead of incremental `push`. Drive-relative inputs (`C:foo`) still skip the verbatim prefix to preserve per-drive CWD semantics (`src/normalize.rs`).
- `anchored_canonicalize` `..` pop now uses `is_strictly_below` (component-wise via `component_eq`) instead of stdlib `Path::starts_with`, so a `Disk`-prefixed anchor floor matches a `VerbatimDisk`-prefixed working path after symlink resolution (`src/anchored.rs`).

### Added

- `src/anchored.rs` — private `is_strictly_below` helper.
- `src/symlink.rs` — `component_eq`, `normalize_and_clamp_to_anchor`, regression test module `clamp_verbatim_regression`.
- `src/normalize.rs` — regression test module `verbatim_prefix_regression` pinning `VerbatimDisk` preservation and the stdlib `starts_with` invariant this fix depends on.
- `tests/anchored_absolute_symlink_dotdot_escape.rs` — anchored `..` escape regression.
- `tests/regression_nul_byte_error_detail.rs` — pins path-aware `soft_canon_detail()`.
- `tests/regression_incomplete_unc_forward_slash.rs` — pins forward-slash UNC rejection.
- `src/tests/anchored_security/windows_symlink.rs::anchored_symlink_or_junction_keeps_clamp_windows` — sibling to `anchored_relative_symlink_keeps_clamp_windows`, uses a directory symlink with NTFS-junction fallback on error 1314 so non-admin / non-Developer-Mode sessions exercise the anchor `..` pop via a real reparse point.

### Changed

- **AGENTS.md rewrite**: reorganized around general-not-reactive / context-free / principles-over-examples. New "Junction Fallback" section codifies the preferred pattern — use `create_symlink_or_junction` (integration tests) or inline junction fallback (unit tests) instead of silently skipping on error 1314. Regression tests are append-only.
- **Test reorganization**: unicode and Windows 8.3 tests split into thematic files.
- **CI — cross-platform Clippy**: `ci-local.sh` / `ci-local.ps1` now run clippy against the complement target (`x86_64-unknown-linux-gnu` on Windows, `x86_64-pc-windows-gnu` on Linux), so cfg-gated files for the opposite platform are linted locally before hitting CI.

## Invariants preserved

- `soft_canonicalize` behavior on fully-existing paths still matches `std::fs::canonicalize` exactly.
- `MAX_SYMLINK_DEPTH`, `SoftCanonicalizeError`, `IoErrorPathExt` public surface unchanged.
- MSRV 1.70.0, zero mandatory runtime deps (all approved optional deps: `proc-canonicalize` default, `dunce` Windows-only optional).
- Windows extended-length output format unchanged; ADS validation still applied early and late.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (host target)
- [x] `cargo clippy --target <complement> --all-targets --all-features -- -D warnings` (cross-platform sweep)
- [x] `cargo test --features anchored,dunce` — all unit + integration + doctests pass on Windows
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Empirical verification that the anchored `..` pop fix is load-bearing (reverting just that change produces `...opt\subdir\special\hello\world` instead of `...opt\subdir\hello\world`)
- [x] New `anchored_symlink_or_junction_keeps_clamp_windows` runs (not skipped) locally via junction fallback — confirmed in test-runner output
- [ ] CI: full matrix (Linux/macOS/Windows × feature combinations × MSRV 1.70)

## Files touched

```
AGENTS.md                                          rewrite + Junction Fallback rules
CHANGELOG.md                                       0.5.6 entry
Cargo.toml                                         version 0.5.5 → 0.5.6, proc-canonicalize 0.1.2 → 0.1.3
ci-local.ps1 / ci-local.sh                         cross-platform clippy
src/anchored.rs                                    is_strictly_below, component_eq-based .. pop
src/lib.rs                                         NUL stage 0 + final pass
src/normalize.rs                                   VerbatimDisk preservation + regression tests
src/symlink.rs                                     component_eq, normalize_and_clamp_to_anchor, regression test
src/windows.rs                                     forward-slash UNC detection
src/tests/security_audit/unicode.rs                reorg + NUL-byte detection test
src/tests/anchored_security/windows_symlink.rs     sibling test with junction fallback
tests/anchored_absolute_symlink_dotdot_escape.rs   new (regression)
tests/regression_incomplete_unc_forward_slash.rs   new (regression)
tests/regression_nul_byte_error_detail.rs          new (regression)
tests/windows_8_3_unit_tests.rs                    reorg
```

## Commits (since v0.5.5)

- `add8d61` security: harden NUL handling, fix anchored `..` escape, reject forward-slash UNC
- `b4cda2c` ci: add cross-platform Clippy checks
- `cd2d0ee` fix: preserve VerbatimDisk prefix in simple_normalize_path
- `63a207c` fix: anchored `..` pop skipped on Disk vs VerbatimDisk prefix mismatch
- `HEAD`   chore: bump to v0.5.6, update CHANGELOG

## Breaking changes

None. Patch release under SemVer: bug fixes and test/doc additions only. No public API changes.
